### PR TITLE
Vec2d tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ build
 
 # VS Code files for those working on multiple tools
 .vscode/*
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Logo](https://github.com/phil-taylor-sj/images/vecplus-logo.png "VecPlus Logo")
+![Logo](https://github.com/phil-taylor-sj/images/vecplus-logo.png)
 
 # VecPlus
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Logo](https://github.com/phil-taylor-sj/images/vecplus-logo.png)
+![Logo](https://raw.githubusercontent.com/phil-taylor-sj/images/vecplus-logo.png)
 
 # VecPlus
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
+![Alt text](https://github.com/phil-taylor-sj/images/VecPlus.png "a title")
+
 # VecPlus
+
+VecPlus is a lightweight library of 2-dimensional and 3-dimensional vector classes.
+I created VecPlus as my own dedicated dependency for projects to avoid duplicating
+the code between multiple projects.
+
+To use the library in a CMake build, use FetchContent to retrieve the library 
+directly from its GitHub repository. 
+
+## Installing as dependency
+
+```
+include(FetchContent)
+FetchContent_Declare(
+  VecPlus
+  GIT_REPOSITORY https://github.com/phil-taylor-sj/VecPlus.git
+  GIT_TAG main
+)
+FetchContent_MakeAvailable(VecPlus)
+```
+
+The library can then be linked to the target executable or target library.
+
+```
+target_link_libraries(${NEW_PROJECT} VecPlus)
+```
+
+## Installing for Development
+
+The test suite covers all tets for 
+
+To setup the library for development & testing, first clone the repository and navigate to the build diretory. Install CMake if it is not already available, and run the CMake build system by referencing the CMakeLists.txt file in the VecPlus root directory.
+
+```
+#Clone
+git clone https://github.com/phil-taylor-sj/VecPlus.git
+cd VecPlus
+
+# Install
+mkdir build
+cd build
+
+
+# Build
+cmake ../
+cmake --build ./
+```
+
+Then carry out the test suite to by running the executable.
+
+```
+./VecPlus_Tests
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Alt text](https://github.com/phil-taylor-sj/images/VecPlus.png "a title")
+![Logo](https://github.com/phil-taylor-sj/images/vecplus-logo.png "VecPlus Logo")
 
 # VecPlus
 
@@ -6,10 +6,12 @@ VecPlus is a lightweight library of 2-dimensional and 3-dimensional vector class
 I created VecPlus as my own dedicated dependency for projects to avoid duplicating
 the code between multiple projects.
 
+
+
+## Installing as Dependency
+
 To use the library in a CMake build, use FetchContent to retrieve the library 
 directly from its GitHub repository. 
-
-## Installing as dependency
 
 ```
 include(FetchContent)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Logo](https://raw.githubusercontent.com/phil-taylor-sj/images/vecplus-logo.png)
+![Logo](https://raw.githubusercontent.com/phil-taylor-sj/images/main/vecplus-logo.png)
 
 # VecPlus
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Logo](https://raw.githubusercontent.com/phil-taylor-sj/images/main/vecplus-logo.png)
+<img src="https://raw.githubusercontent.com/phil-taylor-sj/images/main/vecplus-logo.png" alt="Logo" width="200"/>
 
 # VecPlus
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/phil-taylor-sj/images/main/vecplus-logo.png" alt="Logo" width="200"/>
+<img src="https://raw.githubusercontent.com/phil-taylor-sj/images/main/vecplus-logo.png" alt="Logo" width="400"/>
 
 # VecPlus
 

--- a/include/VecPlus/Vec2Base.h
+++ b/include/VecPlus/Vec2Base.h
@@ -3,12 +3,11 @@
 
 namespace vecp
 {
-    /** 
-     * @brief Represents a 2D vector with components of type T.
+    /*!
+     * \brief Represents a 2D vector with components of type T.
      * 
-     * This class provides basic operations for 2D vectors such as
-     * calculation of magnitude, distance between two vectors, rotartion
-     * and various arithmetic operations.
+     * This template class provides basic operations for generic 2D vectors 
+     * such as addition, subtraction, multiplication, and boolean comparision.
      * 
      * @tparam T The type of elements in the vector (e.g. float, double, int).
      * 
@@ -20,81 +19,82 @@ namespace vecp
         T x; /// The x-coordinate of the vector.
         T y; /// The y-coordinate of the vector.
         
-        /**
-         * @brief Overload the addition operator (+) for vector addition.
+        /*!
+         * \brief Overload the addition operator (+) for vector addition.
          * 
-         * @param vector The vector to be added to  the current vector.
-         * @return A new vector containing the modified values.
+         * \param vector The vector to be added to  the current vector.
+         * \return A new vector containing the modified values.
          * 
         */
         Derived<T> operator + (const Derived<T>& vector) const;
 
-        /**
-         * @brief Overload the addition assignment operator (+=) for vector addition.
+        /*!
+         * \brief Overload the addition assignment operator (+=) for vector addition.
          * 
-         * @param vector The vector to be added to the current vector.
+         * \param vector The vector to be added to the current vector.
         */
         void operator += (const Derived<T> vector);
         
-        /**
-         * @brief Overload the subtration operator (-) for vector subtraction.
+        /*!
+         * \brief Overload the subtration operator (-) for vector subtraction.
          * 
-         * @param vector The vector to be subtracted from the current vector.
-         * @return A new vector containing the modified values.
+         * \param vector The vector to be subtracted from the current vector.
+         * \return A new vector containing the modified values.
          * 
         */
         Derived<T> operator - (const Derived<T>& vector) const;
 
-        /**
-         * @brief Overload the subtraction assignment operator (-=) for vector subtraction.
+        /*!
+         * \brief Overload the subtraction assignment operator (-=) for vector subtraction.
          * 
-         * @param vector The vector to be subtracted from the current vector.
+         * \param vector The vector to be subtracted from the current vector.
         */
         void operator -= (const Derived<T>& vector);
 
-        /**
-         * @brief Overload the multiplication operator (*) for vector by scalar multiplication.
+        /*!
+         * \brief Overload the multiplication operator (*) for vector by scalar multiplication.
          * 
-         * @param value The scalar value to be multiplied.
-         * @return A new vector containing the modified values.
+         * \param value The scalar value to be multiplied.
+         * \return A new vector containing the modified values.
         */
         Derived<T> operator * (T value) const;
         
-        /**
-         * @brief Overload the multiplication operator (*) for vector by vector multiplication.
+        /*!
+         * \brief Overload the multiplication operator (*) for vector by vector multiplication.
          * 
-         * @param vector The vector to multiple the current vector values by.
-         * @return A new vector containing the modified values.
+         * \param vector The vector to multiple the current vector values by.
+         * \return A new vector containing the modified values.
         */
         Derived<T> operator * (const Derived<T>& vector) const;
         
-        /**
-         * @brief Overload the multiplication operator (*=) for vector by scalar multiplication.
+        /*!
+         * \brief Overload the multiplication operator (*=) for vector by scalar multiplication.
          * 
-         * @param value The scalar value to multiply the current vector by.
+         * \param value The scalar value to multiply the current vector by.
         */
         void operator *= (T value);
 
-        /**
-         * @brief Overload the multiplication operator (*=) for vector by vector multiplication.
+        /*!
+         * \brief Overload the multiplication operator (*=) for vector by vector multiplication.
          * 
-         * @param vector The vector multiply the current vector values by.
+         * \param vector The vector multiply the current vector values by.
         */
         void operator *= (const Derived<T>& vector);
 
-        /**
-         * @brief Overload the equality operator (==) for vector comparison.
+        /*!
+         * \brief Overload the equality operator (==) for vector comparison.
          *
-         * @param vector The vector to compare with.
-         * @return True if both vector components are equal, otherwise false.
+         * \param vector The vector to compare with.
+         * \return True if both vector components are equal, otherwise false.
         */
+
         bool operator == (const Derived<T>& vector);
 
-        /**
-         * @brief Construct a new Vec2 object with given x and y components.
+        /*!
+         * \brief Construct a new Vec2 object with given x and y components.
          * 
-         * @param xin The x component of the vector.
-         * @param yin The y component of the vector.
+         * \param xin The x component of the vector.
+         * \param yin The y component of the vector.
         */
         Vec2Base(T xin = T(), T yin = T()) : x(xin), y(yin) {}
     };

--- a/include/VecPlus/Vec2Decimal.h
+++ b/include/VecPlus/Vec2Decimal.h
@@ -98,7 +98,12 @@ namespace vecp
         */
         T dot(T xTwo, T yTwo) const;
 
-
+        /*!
+         * \brief Normalise the current vector and return the result as a new vector.
+         *
+         * \return A new vector containing the normalised x and y components.
+        */
+       Vec2Decimal<T> normalise() const;
 
         /**
          * \brief Convert current vector to a Vec2f instance.
@@ -112,7 +117,9 @@ namespace vecp
          * 
          * \return A new vector containing the equivalent double values.
          */
-        Vec2Decimal<double> toDouble() const;        using Vec2Base<T, Vec2Decimal>::Vec2Base;
+        Vec2Decimal<double> toDouble() const;
+
+        using Vec2Base<T, Vec2Decimal>::Vec2Base;
         //Vec2fd(T xin = 0., T yin = 0.);
 
     private:

--- a/include/VecPlus/Vec2Decimal.h
+++ b/include/VecPlus/Vec2Decimal.h
@@ -40,7 +40,7 @@ namespace vecp
          * 
          * \param angle The angle (in degrees) by which to rotate the vector.
         */
-        void rotate(T angle);
+        Vec2Decimal<T> rotate(T angle) const;
 
 
         /*!
@@ -98,7 +98,21 @@ namespace vecp
         */
         T dot(T xTwo, T yTwo) const;
 
-        using Vec2Base<T, Vec2Decimal>::Vec2Base;
+
+
+        /**
+         * \brief Convert current vector to a Vec2f instance.
+         * 
+         * \return A new vector containing the equivalent float values.
+         */
+        Vec2Decimal<float> toFloat() const;
+        
+        /**
+         * \brief Convert current vector to a Vec2d instance.
+         * 
+         * \return A new vector containing the equivalent double values.
+         */
+        Vec2Decimal<double> toDouble() const;        using Vec2Base<T, Vec2Decimal>::Vec2Base;
         //Vec2fd(T xin = 0., T yin = 0.);
 
     private:

--- a/include/VecPlus/Vec2Decimal.h
+++ b/include/VecPlus/Vec2Decimal.h
@@ -90,7 +90,7 @@ namespace vecp
         T dot(T value) const;
 
         /*!
-         * \brief Calculate dot product of the current vector a vector of two scalar values.
+         * \brief Calculate dot product of the current vector and a vector of two scalar values.
          * 
          * \param xTwo The x scalar value to apply to the current vector.
          * \param yTwo The y scalar valeu to apply to the current vector.

--- a/include/VecPlus/Vec2Decimal.h
+++ b/include/VecPlus/Vec2Decimal.h
@@ -4,14 +4,13 @@
 namespace vecp
 {
 
-    /** 
-     * @brief Represents a 2D vector with components of type T.
+    /*! 
+     * \brief Represents a 2D vector with components of primative decimal types.
      * 
-     * This class provides basic operations for 2D vectors such as
-     * calculation of magnitude, distance between two vectors, rotartion
-     * and various arithmetic operations.
+     * Extends the Vec2Base class with functionality for division, rotation, 
+     * calculation of mangitude, and calculation of the dot product.
      * 
-     * @tparam T The type of elements in the vector (e.g. float, double, int).
+     * \tparam T The type of elements in the vector (e.g. float, double, int).
      * 
     */
     template <typename T>
@@ -19,84 +18,83 @@ namespace vecp
     {
     public:
         
-        /**
-         * @brief Calculate the magnitude (length) of the vector.
+        /*!
+         * \brief Calculate the magnitude (length) of the vector.
          * 
-         * @return The magnitude of the vector.
-         * 
+         * \return The magnitude of the vector. 
         */
         T mag() const;
 
-        /**
-         * @brief Calcualte the magnitude (legnth) of the distance vector between
+        /*!
+         * \brief Calcualte the magnitude (legnth) of the distance vector between
          * this vector and another vector.
          * 
-         * @param vector The other vector to calculate the distance vector between.
-         * @return The magnitude of the transform vector.
+         * \param vector The other vector to calculate the distance vector between.
+         * \return The magnitude of the transform vector.
          * 
         */
         T mag(const Vec2Decimal<T>& vector) const;
 
-        /**
-         * @brief Apply a rotation to the vector by a given angle.
+        /*!
+         * \brief Apply a rotation to the vector by a given angle.
          * 
-         * @param angle The angle (in degrees) by which to rotate the vector.
+         * \param angle The angle (in degrees) by which to rotate the vector.
         */
         void rotate(T angle);
 
 
-        /**
-         * @brief Overload the division operator (/) for vector by scalar division.
+        /*!
+         * \brief Overload the division operator (/) for vector by scalar division.
          * 
-         * @param value The scalar value to divide the current vector by.
-         * @return A new vector containing the modified values.
+         * \param value The scalar value to divide the current vector by.
+         * \return A new vector containing the modified values.
         */
         Vec2Decimal<T> operator / (T value) const;
 
-        /**
-         * @brief Overload the division operator (/) for vector by vector division.
+        /*!
+         * \brief Overload the division operator (/) for vector by vector division.
          * 
-         * @param vector The vector to divide the current vector values by.
-         * @return A new vector containing the modified values.
+         * \param vector The vector to divide the current vector values by.
+         * \return A new vector containing the modified values.
         */
         Vec2Decimal<T> operator / (const Vec2Decimal<T>& vector) const;
         
-        /**
-         * @brief Overload the division operator (/=) for vector by scalar division.
+        /*!
+         * \brief Overload the division operator (/=) for vector by scalar division.
          * 
-         * @param value The scalar value to divide the current vector by.
+         * \param value The scalar value to divide the current vector by.
         */
         void operator /= (T value);
 
-        /**
-         * @brief Overload the division operator (/=) for vector by scalar division.
+        /*!
+         * \brief Overload the division operator (/=) for vector by scalar division.
          * 
-         * @param vector The vector to divide the current vector values by.
+         * \param vector The vector to divide the current vector values by.
         */
         void operator /= (const Vec2Decimal<T>& vector);
 
-        /**
-         * @brief Calculate dot product of the current vector and another vector.
+        /*!
+         * \brief Calculate dot product of the current vector and another vector.
          * 
-         * @param vector The vector to apply to the current vector.
-         * @return The dot product of the vectors.
+         * \param vector The vector to apply to the current vector.
+         * \return The dot product of the vectors.
         */
         T dot(const Vec2Decimal<T>& vector) const;
 
-        /**
-         * @brief Calculate dot product of the current vector a vector of two identical scalar values.
+        /*!
+         * \brief Calculate dot product of the current vector a vector of two identical scalar values.
          * 
-         * @param value The x & y scalar value to apply to the current vector.
-         * @return The dot product of the vectors.
+         * \param value The x & y scalar value to apply to the current vector.
+         * \return The dot product of the vectors.
         */
         T dot(T value) const;
 
-        /**
-         * @brief Calculate dot product of the current vector a vector of two scalar values.
+        /*!
+         * \brief Calculate dot product of the current vector a vector of two scalar values.
          * 
-         * @param xTwo The x scalar value to apply to the current vector.
-         * @param yTwo The y scalar valeu to apply to the current vector.
-         * @return The dot product of the vectors.
+         * \param xTwo The x scalar value to apply to the current vector.
+         * \param yTwo The y scalar valeu to apply to the current vector.
+         * \return The dot product of the vectors.
         */
         T dot(T xTwo, T yTwo) const;
 

--- a/include/VecPlus/Vec2Int.h
+++ b/include/VecPlus/Vec2Int.h
@@ -18,16 +18,16 @@ namespace vecp
     {
     public:
         /**
-         * @brief Convert current vector to a Vec2f instance.
+         * \brief Convert current vector to a Vec2f instance.
          * 
-         * @return A new vector containing the equivalent float values.
+         * \return A new vector containing the equivalent float values.
          */
         Vec2Decimal<float> toFloat() const;
         
         /**
-         * @brief Convert current vector to a Vec2d instance.
+         * \brief Convert current vector to a Vec2d instance.
          * 
-         * @return A new vector containing the equivalent double values.
+         * \return A new vector containing the equivalent double values.
          */
         Vec2Decimal<double> toDouble() const;
 

--- a/include/VecPlus/Vec2Int.h
+++ b/include/VecPlus/Vec2Int.h
@@ -4,7 +4,15 @@
 
 namespace vecp
 {
-
+    /*!
+     * \brief Represents a 2D vector with components of privative integer types.
+     * 
+     * Extends the Vec2Base class with functionaltiy for converting the vector 
+     * into a Vec2Decimal types of either floats or doubles.
+     * 
+     * @tparam T The type of elements in the vector (e.g. float, double, int).
+     * 
+    */
     template<typename T>
     class Vec2Int : public Vec2Base<T, Vec2Int>
     {

--- a/src/VecPlus/Vec2Decimal.cpp
+++ b/src/VecPlus/Vec2Decimal.cpp
@@ -72,6 +72,14 @@ namespace vecp
         return this->x * xTwo + this->y * yTwo;
     }
 
+    template <typename T>
+    Vec2Decimal<T> Vec2Decimal<T>::normalise() const
+    {
+        T magnitude = sqrt(pow(this->x, 2) + pow(this->y, 2));
+        return Vec2Decimal<T>(this->x / magnitude, this->y / magnitude);
+    }
+
+
     template<typename T>
     Vec2Decimal<float> Vec2Decimal<T>::toFloat() const
     {

--- a/src/VecPlus/Vec2Decimal.cpp
+++ b/src/VecPlus/Vec2Decimal.cpp
@@ -18,13 +18,14 @@ namespace vecp
     }
 
     template <typename T>
-    void Vec2Decimal<T>::rotate(T angle)
+    Vec2Decimal<T> Vec2Decimal<T>::rotate(T angle) const
     {
-        T xo = this->x;
         T cosAngle = cos(angle * this->m_pi / 180.);
         T sinAngle = sin(angle * this->m_pi / 180.);
-        this->x = this->x * cosAngle - this->y * sinAngle;
-        this->y = xo * sinAngle + this->y * cosAngle;
+        return Vec2Decimal<T> (
+            this->x * cosAngle - this->y * sinAngle,
+            this->x * sinAngle + this->y * cosAngle
+        );
     }
 
     template <typename T>
@@ -69,6 +70,18 @@ namespace vecp
     T Vec2Decimal<T>::dot(T xTwo, T yTwo) const
     {
         return this->x * xTwo + this->y * yTwo;
+    }
+
+    template<typename T>
+    Vec2Decimal<float> Vec2Decimal<T>::toFloat() const
+    {
+        return Vec2Decimal<float>((float)this->x, (float)this->y);
+    }
+
+    template<typename T>
+    Vec2Decimal<double> Vec2Decimal<T>::toDouble() const
+    {
+        return Vec2Decimal<double>((double)this->x, (double)this->y);
     }
 
     template class Vec2Base<float, Vec2Decimal>;

--- a/src/VecPlus/Vec2Int.cpp
+++ b/src/VecPlus/Vec2Int.cpp
@@ -18,7 +18,6 @@ namespace vecp
         return Vec2Decimal<double>((double)this->x, (double)this->y);
     }
 
-
     template class Vec2Base<int, Vec2Int>;
 
     template class Vec2Int<int>;

--- a/src/VecPlus/Vec2Int.cpp
+++ b/src/VecPlus/Vec2Int.cpp
@@ -22,11 +22,6 @@ namespace vecp
     template class Vec2Base<int, Vec2Int>;
 
     template class Vec2Int<int>;
-    //template<typename T>
-    //Vec2int<T>::Vec2int(int xin, int yin) : Vec2b<T, Vec2int>(xin, yin)
-    //{
-    //
-    //}
 }    
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ set(TEST_TARGET VecPlus_Tests)
 set(TEST_SRCS
     pch.cpp
     pch.h
-    Vec2Int_Test.cpp
+    Vec2i_Test.cpp
     Vec2d_Test.cpp
     Vec2f_Test.cpp
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,8 @@ set(TEST_SRCS
     pch.cpp
     pch.h
     Vec2Int_Test.cpp
+    Vec2d_Test.cpp
+    Vec2f_Test.cpp
 )
 
 include(FetchContent)

--- a/test/Vec2d_Test.cpp
+++ b/test/Vec2d_Test.cpp
@@ -249,22 +249,6 @@ namespace Vec2d_Tests
         std::make_tuple(Vec2d(8.8, -7.7), Vec2d(4.4, -7.7), Vec2d(2.0, 1.0))
     ));
 
-    // void operator /= (const Vec2d& vector)
-    class Vec2d_DivideEqualsByVectorF : public Vec2d_VecVecVecFixture {};
-    TEST_P(Vec2d_DivideEqualsByVectorF, Vec2d_DivideEqualsByVector)
-    {
-        vectorOne /= vectorTwo;
-        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
-        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);   
-    }
-
-    INSTANTIATE_TEST_SUITE_P(Vec2d_DivideEqualsByVector, Vec2d_DivideEqualsByVectorF, testing::Values(
-        std::make_tuple(Vec2d(10.0, 20.0), Vec2d(2.0, 4.0), Vec2d(5.0, 5.0)),
-        std::make_tuple(Vec2d(-6.6, 4.4), Vec2d(-2.2, 2.2), Vec2d(3.0, 2.0)),
-        std::make_tuple(Vec2d(10.0, -5.0), Vec2d(2.0, -5.0), Vec2d(5.0, 1.0)),
-        std::make_tuple(Vec2d(8.8, -7.7), Vec2d(4.4, -7.7), Vec2d(2.0, 1.0))
-    ));
-
     // void operator /= (double scalar)
     class Vec2d_DivideEqualsByScalarF : public Vec2d_VecScaVecFixture {};
     TEST_P(Vec2d_DivideEqualsByScalarF, Vec2d_DivideEqualsByScalar)
@@ -280,5 +264,21 @@ namespace Vec2d_Tests
         std::make_tuple(Vec2d(10.0, -5.0), 2.0, Vec2d(5.0, -2.5)),
         std::make_tuple(Vec2d(8.8, -7.7), 4.4, Vec2d(2.0, -1.75)),
         std::make_tuple(Vec2d(9.0, 12.0), 3.0, Vec2d(3.0, 4.0))  // Additional test case
+    ));
+
+    // void operator /= (const Vec2d& vector)
+    class Vec2d_DivideEqualsByVectorF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_DivideEqualsByVectorF, Vec2d_DivideEqualsByVector)
+    {
+        vectorOne /= vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
+        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_DivideEqualsByVector, Vec2d_DivideEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec2d(10.0, 20.0), Vec2d(2.0, 4.0), Vec2d(5.0, 5.0)),
+        std::make_tuple(Vec2d(-6.6, 4.4), Vec2d(-2.2, 2.2), Vec2d(3.0, 2.0)),
+        std::make_tuple(Vec2d(10.0, -5.0), Vec2d(2.0, -5.0), Vec2d(5.0, 1.0)),
+        std::make_tuple(Vec2d(8.8, -7.7), Vec2d(4.4, -7.7), Vec2d(2.0, 1.0))
     ));
 }

--- a/test/Vec2d_Test.cpp
+++ b/test/Vec2d_Test.cpp
@@ -9,19 +9,19 @@ namespace Vec2d_Tests
     TEST(TestConstructorDefault, SetDefaultValues)
     {   
         Vec2d vector = Vec2d();
-        ASSERT_EQ(vector.x, 0.0);
-        ASSERT_EQ(vector.y, 0.0);
+        ASSERT_DOUBLE_EQ(vector.x, 0.0);
+        ASSERT_DOUBLE_EQ(vector.y, 0.0);
     }
 
     // Constructor with specified values test
     TEST(TestConstructorValues, SetSpecifiedValues)
     {
         Vec2d vector = Vec2d(-3.5, 4.2);
-        ASSERT_EQ(vector.x, -3.5);
-        ASSERT_EQ(vector.y, 4.2);
+        ASSERT_DOUBLE_EQ(vector.x, -3.5);
+        ASSERT_DOUBLE_EQ(vector.y, 4.2);
     }
 
-    class VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2d, double, Vec2d>>
+    class Vec2d_VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2d, double, Vec2d>>
     {
     protected:
         void SetUp() override
@@ -34,7 +34,7 @@ namespace Vec2d_Tests
         double scalar;
     };
 
-    class VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2d, Vec2d, Vec2d>>
+    class Vec2d_VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2d, Vec2d, Vec2d>>
     {
     protected:
         void SetUp() override
@@ -47,15 +47,15 @@ namespace Vec2d_Tests
     };
 
     // Vec2d operator + (const Vec2d& vector) const
-    class AddVectorF : public VecVecVecFixture {};
-    TEST_P(AddVectorF, AddVector)
+    class Vec2d_AddVectorF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_AddVectorF, Vec2d_AddVector)
     {
         Vec2d output = vectorOne + vectorTwo;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(AddVector, AddVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2d_AddVector, Vec2d_AddVectorF, testing::Values(
         std::make_tuple(Vec2d(1.1, 2.2), Vec2d(3.3, 4.4), Vec2d(4.4, 6.6)),
         std::make_tuple(Vec2d(-2.5, 5.1), Vec2d(7.2, -3.3), Vec2d(4.7, 1.8)),
         std::make_tuple(Vec2d(0.0, -8.4), Vec2d(-4.4, 6.6), Vec2d(-4.4, -1.8)),
@@ -63,15 +63,15 @@ namespace Vec2d_Tests
     ));
 
     // void operator += (const Vec2d& vector)
-    class AddEqualsVectorF : public VecVecVecFixture {};
-    TEST_P(AddEqualsVectorF, AddEqualsVector)
+    class Vec2d_AddEqualsVectorF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_AddEqualsVectorF, Vec2d_AddEqualsVector)
     {
         vectorOne += vectorTwo;
-        ASSERT_EQ(expected.x, vectorOne.x);
-        ASSERT_EQ(expected.y, vectorOne.y);
+        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
+        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(AddEqualsVector, AddEqualsVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2d_AddEqualsVector, Vec2d_AddEqualsVectorF, testing::Values(
         std::make_tuple(Vec2d(1.1, 2.2), Vec2d(3.3, 4.4), Vec2d(4.4, 6.6)),
         std::make_tuple(Vec2d(-2.5, 5.1), Vec2d(7.2, -3.3), Vec2d(4.7, 1.8)),
         std::make_tuple(Vec2d(0.0, -8.4), Vec2d(-4.4, 6.6), Vec2d(-4.4, -1.8)),
@@ -79,15 +79,15 @@ namespace Vec2d_Tests
     ));
 
     // Vec2d operator - (const Vec2d& vector) const
-    class SubtractVectorF : public VecVecVecFixture {};
-    TEST_P(SubtractVectorF, SubtractVector)
+    class Vec2d_SubtractVectorF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_SubtractVectorF, SubtractVector)
     {
         Vec2d output = vectorOne - vectorTwo;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(SubtractVector, SubtractVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2d_SubtractVector, Vec2d_SubtractVectorF, testing::Values(
         std::make_tuple(Vec2d(5.5, 7.7), Vec2d(3.3, 2.2), Vec2d(2.2, 5.5)),
         std::make_tuple(Vec2d(10.0, 10.0), Vec2d(4.5, 6.5), Vec2d(5.5, 3.5)),
         std::make_tuple(Vec2d(-3.3, 8.8), Vec2d(2.2, -5.5), Vec2d(-5.5, 14.3)),
@@ -95,15 +95,15 @@ namespace Vec2d_Tests
     ));
 
     // void operator -= (const Vec2d& vector)
-    class SubtractEqualsVectorF : public VecVecVecFixture {};
-    TEST_P(SubtractEqualsVectorF, SubtractEqualsVector)
+    class Vec2d_SubtractEqualsVectorF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_SubtractEqualsVectorF, Vec2d_SubtractEqualsVector)
     {
         vectorOne -= vectorTwo;
-        ASSERT_EQ(expected.x, vectorOne.x);
-        ASSERT_EQ(expected.y, vectorOne.y);
+        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
+        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(SubtractEqualsVector, SubtractEqualsVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2d_SubtractEqualsVector, Vec2d_SubtractEqualsVectorF, testing::Values(
         std::make_tuple(Vec2d(5.5, 7.7), Vec2d(3.3, 2.2), Vec2d(2.2, 5.5)),
         std::make_tuple(Vec2d(10.0, 10.0), Vec2d(4.5, 6.5), Vec2d(5.5, 3.5)),
         std::make_tuple(Vec2d(-3.3, 8.8), Vec2d(2.2, -5.5), Vec2d(-5.5, 14.3)),
@@ -111,15 +111,15 @@ namespace Vec2d_Tests
     ));
 
     // Vec2d operator * (double scalar) const
-    class MultiplyByScalarF : public VecScaVecFixture {};
-    TEST_P(MultiplyByScalarF, MultiplyByScalar)
+    class Vec2d_MultiplyByScalarF : public Vec2d_VecScaVecFixture {};
+    TEST_P(Vec2d_MultiplyByScalarF, Vec2d_MultiplyByScalar)
     {
         Vec2d output = vector * scalar;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);   
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyByScalar, MultiplyByScalarF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2d_MultiplyByScalar, Vec2d_MultiplyByScalarF, testing::Values(
         std::make_tuple(Vec2d(0.0, 0.0), 10.0, Vec2d(0.0, 0.0)),
         std::make_tuple(Vec2d(3.3, 4.4), 10.0, Vec2d(33.0, 44.0)),
         std::make_tuple(Vec2d(-6.6, 4.4), 5.0, Vec2d(-33.0, 22.0)),
@@ -127,15 +127,15 @@ namespace Vec2d_Tests
     ));
 
     // Vec2d operator * (const Vec2d& vector) const
-    class MultiplyByVectorF : public VecVecVecFixture {};
-    TEST_P(MultiplyByVectorF, MultiplyByVector)
+    class Vec2d_MultiplyByVectorF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_MultiplyByVectorF, Vec2d_MultiplyByVector)
     {
         Vec2d output = vectorOne * vectorTwo;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);   
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyByVector, MultiplyByVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2d_MultiplyByVector, Vec2d_MultiplyByVectorF, testing::Values(
         std::make_tuple(Vec2d(0.0, 0.0), Vec2d(10.0, 10.0), Vec2d(0.0, 0.0)),
         std::make_tuple(Vec2d(3.3, 4.4), Vec2d(5.5, 10.0), Vec2d(18.15, 44.0)),
         std::make_tuple(Vec2d(-6.6, 4.4), Vec2d(5.5, -5.0), Vec2d(-36.3, -22.0)),
@@ -143,15 +143,15 @@ namespace Vec2d_Tests
     ));
 
     // void operator *= (double scalar)
-    class MultiplyEqualsByScalarF : public VecScaVecFixture {};
-    TEST_P(MultiplyEqualsByScalarF, MultiplyEqualsByScalar)
+    class Vec2d_MultiplyEqualsByScalarF : public Vec2d_VecScaVecFixture {};
+    TEST_P(Vec2d_MultiplyEqualsByScalarF, Vec2d_MultiplyEqualsByScalar)
     {
         vector *= scalar;
-        ASSERT_EQ(expected.x, vector.x);
-        ASSERT_EQ(expected.y, vector.y);   
+        ASSERT_DOUBLE_EQ(expected.x, vector.x);
+        ASSERT_DOUBLE_EQ(expected.y, vector.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByScalar, MultiplyEqualsByScalarF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2d_MultiplyEqualsByScalar, Vec2d_MultiplyEqualsByScalarF, testing::Values(
         std::make_tuple(Vec2d(0.0, 0.0), 10.0, Vec2d(0.0, 0.0)),
         std::make_tuple(Vec2d(3.3, 4.4), 10.0, Vec2d(33.0, 44.0)),
         std::make_tuple(Vec2d(-6.6, 4.4), 5.0, Vec2d(-33.0, 22.0)),
@@ -159,22 +159,22 @@ namespace Vec2d_Tests
     ));
 
     // void operator *= (const Vec2d& vector)
-    class MultiplyEqualsByVectorF : public VecVecVecFixture {};
-    TEST_P(MultiplyEqualsByVectorF, MultiplyEqualsByVector)
+    class Vec2d_MultiplyEqualsByVectorF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_MultiplyEqualsByVectorF, Vec2d_MultiplyEqualsByVector)
     {
         vectorOne *= vectorTwo;
-        ASSERT_EQ(expected.x, vectorOne.x);
-        ASSERT_EQ(expected.y, vectorOne.y);   
+        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
+        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByVector, MultiplyEqualsByVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2d_MultiplyEqualsByVector, Vec2d_MultiplyEqualsByVectorF, testing::Values(
         std::make_tuple(Vec2d(0.0, 0.0), Vec2d(10.0, 10.0), Vec2d(0.0, 0.0)),
         std::make_tuple(Vec2d(3.3, 4.4), Vec2d(5.5, 10.0), Vec2d(18.15, 44.0)),
         std::make_tuple(Vec2d(-6.6, 4.4), Vec2d(5.5, -5.0), Vec2d(-36.3, -22.0)),
         std::make_tuple(Vec2d(8.8, -7.7), Vec2d(-5.5, -5.5), Vec2d(-48.4, 42.35))
     ));
 
-    class VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2d, Vec2d, bool>>
+    class Vec2d_VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2d, Vec2d, bool>>
     {
     protected:
         void SetUp() override
@@ -188,15 +188,15 @@ namespace Vec2d_Tests
     };
 
     // bool operator == (const Vec2d& vector) const
-    class CompareVectorsF : public VecVecBoolFixture {};
-    TEST_P(CompareVectorsF, CompareVectors)
+    class Vec2d_CompareVectorsF : public Vec2d_VecVecBoolFixture {};
+    TEST_P(Vec2d_CompareVectorsF, Vec2d_CompareVectors)
     {
         bool output = vectorOne == vectorTwo;
-        ASSERT_EQ(expected, output);
-        ASSERT_EQ(expected, output);   
+        ASSERT_DOUBLE_EQ(expected, output);
+        ASSERT_DOUBLE_EQ(expected, output);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(CompareVectors, CompareVectorsF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2d_CompareVectors, Vec2d_CompareVectorsF, testing::Values(
         std::make_tuple(Vec2d(-5.5, 5.5), Vec2d(-5.5, 5.5), true),
         std::make_tuple(Vec2d(0.0, 0.0), Vec2d(0.0, 0.0), true),
         std::make_tuple(Vec2d(-5.5, 5.5), Vec2d(5.5, -5.5), false),

--- a/test/Vec2d_Test.cpp
+++ b/test/Vec2d_Test.cpp
@@ -1,0 +1,205 @@
+#include "pch.h"
+#include <VecPlus/Vec2.h>
+#include <iostream>
+
+using namespace vecp;
+
+namespace Vec2d_Tests
+{
+    TEST(TestConstructorDefault, SetDefaultValues)
+    {   
+        Vec2d vector = Vec2d();
+        ASSERT_EQ(vector.x, 0.0);
+        ASSERT_EQ(vector.y, 0.0);
+    }
+
+    // Constructor with specified values test
+    TEST(TestConstructorValues, SetSpecifiedValues)
+    {
+        Vec2d vector = Vec2d(-3.5, 4.2);
+        ASSERT_EQ(vector.x, -3.5);
+        ASSERT_EQ(vector.y, 4.2);
+    }
+
+    class VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2d, double, Vec2d>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vector = std::get<0>(GetParam());
+            scalar = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2d vector, expected;
+        double scalar;
+    };
+
+    class VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2d, Vec2d, Vec2d>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2d vectorOne, vectorTwo, expected;
+    };
+
+    // Vec2d operator + (const Vec2d& vector) const
+    class AddVectorF : public VecVecVecFixture {};
+    TEST_P(AddVectorF, AddVector)
+    {
+        Vec2d output = vectorOne + vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(AddVector, AddVectorF, testing::Values(
+        std::make_tuple(Vec2d(1.1, 2.2), Vec2d(3.3, 4.4), Vec2d(4.4, 6.6)),
+        std::make_tuple(Vec2d(-2.5, 5.1), Vec2d(7.2, -3.3), Vec2d(4.7, 1.8)),
+        std::make_tuple(Vec2d(0.0, -8.4), Vec2d(-4.4, 6.6), Vec2d(-4.4, -1.8)),
+        std::make_tuple(Vec2d(10.0, -10.0), Vec2d(-10.0, 10.0), Vec2d(0.0, 0.0))
+    ));
+
+    // void operator += (const Vec2d& vector)
+    class AddEqualsVectorF : public VecVecVecFixture {};
+    TEST_P(AddEqualsVectorF, AddEqualsVector)
+    {
+        vectorOne += vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(AddEqualsVector, AddEqualsVectorF, testing::Values(
+        std::make_tuple(Vec2d(1.1, 2.2), Vec2d(3.3, 4.4), Vec2d(4.4, 6.6)),
+        std::make_tuple(Vec2d(-2.5, 5.1), Vec2d(7.2, -3.3), Vec2d(4.7, 1.8)),
+        std::make_tuple(Vec2d(0.0, -8.4), Vec2d(-4.4, 6.6), Vec2d(-4.4, -1.8)),
+        std::make_tuple(Vec2d(10.0, -10.0), Vec2d(-10.0, 10.0), Vec2d(0.0, 0.0))
+    ));
+
+    // Vec2d operator - (const Vec2d& vector) const
+    class SubtractVectorF : public VecVecVecFixture {};
+    TEST_P(SubtractVectorF, SubtractVector)
+    {
+        Vec2d output = vectorOne - vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(SubtractVector, SubtractVectorF, testing::Values(
+        std::make_tuple(Vec2d(5.5, 7.7), Vec2d(3.3, 2.2), Vec2d(2.2, 5.5)),
+        std::make_tuple(Vec2d(10.0, 10.0), Vec2d(4.5, 6.5), Vec2d(5.5, 3.5)),
+        std::make_tuple(Vec2d(-3.3, 8.8), Vec2d(2.2, -5.5), Vec2d(-5.5, 14.3)),
+        std::make_tuple(Vec2d(0.0, 0.0), Vec2d(-7.7, 9.9), Vec2d(7.7, -9.9))
+    ));
+
+    // void operator -= (const Vec2d& vector)
+    class SubtractEqualsVectorF : public VecVecVecFixture {};
+    TEST_P(SubtractEqualsVectorF, SubtractEqualsVector)
+    {
+        vectorOne -= vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(SubtractEqualsVector, SubtractEqualsVectorF, testing::Values(
+        std::make_tuple(Vec2d(5.5, 7.7), Vec2d(3.3, 2.2), Vec2d(2.2, 5.5)),
+        std::make_tuple(Vec2d(10.0, 10.0), Vec2d(4.5, 6.5), Vec2d(5.5, 3.5)),
+        std::make_tuple(Vec2d(-3.3, 8.8), Vec2d(2.2, -5.5), Vec2d(-5.5, 14.3)),
+        std::make_tuple(Vec2d(0.0, 0.0), Vec2d(-7.7, 9.9), Vec2d(7.7, -9.9))
+    ));
+
+    // Vec2d operator * (double scalar) const
+    class MultiplyByScalarF : public VecScaVecFixture {};
+    TEST_P(MultiplyByScalarF, MultiplyByScalar)
+    {
+        Vec2d output = vector * scalar;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyByScalar, MultiplyByScalarF, testing::Values(
+        std::make_tuple(Vec2d(0.0, 0.0), 10.0, Vec2d(0.0, 0.0)),
+        std::make_tuple(Vec2d(3.3, 4.4), 10.0, Vec2d(33.0, 44.0)),
+        std::make_tuple(Vec2d(-6.6, 4.4), 5.0, Vec2d(-33.0, 22.0)),
+        std::make_tuple(Vec2d(8.8, -7.7), -5.0, Vec2d(-44.0, 38.5))
+    ));
+
+    // Vec2d operator * (const Vec2d& vector) const
+    class MultiplyByVectorF : public VecVecVecFixture {};
+    TEST_P(MultiplyByVectorF, MultiplyByVector)
+    {
+        Vec2d output = vectorOne * vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyByVector, MultiplyByVectorF, testing::Values(
+        std::make_tuple(Vec2d(0.0, 0.0), Vec2d(10.0, 10.0), Vec2d(0.0, 0.0)),
+        std::make_tuple(Vec2d(3.3, 4.4), Vec2d(5.5, 10.0), Vec2d(18.15, 44.0)),
+        std::make_tuple(Vec2d(-6.6, 4.4), Vec2d(5.5, -5.0), Vec2d(-36.3, -22.0)),
+        std::make_tuple(Vec2d(8.8, -7.7), Vec2d(-5.5, -5.5), Vec2d(-48.4, 42.35))
+    ));
+
+    // void operator *= (double scalar)
+    class MultiplyEqualsByScalarF : public VecScaVecFixture {};
+    TEST_P(MultiplyEqualsByScalarF, MultiplyEqualsByScalar)
+    {
+        vector *= scalar;
+        ASSERT_EQ(expected.x, vector.x);
+        ASSERT_EQ(expected.y, vector.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByScalar, MultiplyEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec2d(0.0, 0.0), 10.0, Vec2d(0.0, 0.0)),
+        std::make_tuple(Vec2d(3.3, 4.4), 10.0, Vec2d(33.0, 44.0)),
+        std::make_tuple(Vec2d(-6.6, 4.4), 5.0, Vec2d(-33.0, 22.0)),
+        std::make_tuple(Vec2d(8.8, -7.7), -5.0, Vec2d(-44.0, 38.5))
+    ));
+
+    // void operator *= (const Vec2d& vector)
+    class MultiplyEqualsByVectorF : public VecVecVecFixture {};
+    TEST_P(MultiplyEqualsByVectorF, MultiplyEqualsByVector)
+    {
+        vectorOne *= vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByVector, MultiplyEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec2d(0.0, 0.0), Vec2d(10.0, 10.0), Vec2d(0.0, 0.0)),
+        std::make_tuple(Vec2d(3.3, 4.4), Vec2d(5.5, 10.0), Vec2d(18.15, 44.0)),
+        std::make_tuple(Vec2d(-6.6, 4.4), Vec2d(5.5, -5.0), Vec2d(-36.3, -22.0)),
+        std::make_tuple(Vec2d(8.8, -7.7), Vec2d(-5.5, -5.5), Vec2d(-48.4, 42.35))
+    ));
+
+    class VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2d, Vec2d, bool>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2d vectorOne, vectorTwo;
+        bool expected;
+    };
+
+    // bool operator == (const Vec2d& vector) const
+    class CompareVectorsF : public VecVecBoolFixture {};
+    TEST_P(CompareVectorsF, CompareVectors)
+    {
+        bool output = vectorOne == vectorTwo;
+        ASSERT_EQ(expected, output);
+        ASSERT_EQ(expected, output);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(CompareVectors, CompareVectorsF, testing::Values(
+        std::make_tuple(Vec2d(-5.5, 5.5), Vec2d(-5.5, 5.5), true),
+        std::make_tuple(Vec2d(0.0, 0.0), Vec2d(0.0, 0.0), true),
+        std::make_tuple(Vec2d(-5.5, 5.5), Vec2d(5.5, -5.5), false),
+        std::make_tuple(Vec2d(6.1, 0.0), Vec2d(7.1, 0.0), false)
+    ));
+}

--- a/test/Vec2d_Test.cpp
+++ b/test/Vec2d_Test.cpp
@@ -387,6 +387,21 @@ namespace Vec2d_Tests
             float expectedX, expectedY;
     };
 
+    // Vec2d Vec2d::normalise() const
+    class Vec2d_NormaliseF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_NormaliseF, Vec2d_Normalise)
+    {
+        Vec2d output = vectorOne.normalise();
+        ASSERT_NEAR(expected.x, output.x, 1E-05);
+        ASSERT_NEAR(expected.y, output.y, 1E-05);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_Normalise, Vec2d_NormaliseF, testing::Values(
+        std::make_tuple(Vec2d(5., 5.), Vec2d(0., 0.), Vec2d(0.707107, 0.707107)),
+        std::make_tuple(Vec2d(-5., -5.), Vec2d(0., 0.), Vec2d(-0.707107, -0.707107)),
+        std::make_tuple(Vec2d(-6., 8.), Vec2d(0., 0.), Vec2d(-0.6, 0.8))
+    ));
+
     // Vec2d Vec2d::toFloat() const
     class Vec2d_ConvertToFloatF : public Vec2d_VecFloatFloatFixture {};
     TEST_P(Vec2d_ConvertToFloatF, Vec2f_ConvertToFloat)

--- a/test/Vec2d_Test.cpp
+++ b/test/Vec2d_Test.cpp
@@ -202,4 +202,83 @@ namespace Vec2d_Tests
         std::make_tuple(Vec2d(-5.5, 5.5), Vec2d(5.5, -5.5), false),
         std::make_tuple(Vec2d(6.1, 0.0), Vec2d(7.1, 0.0), false)
     ));
+
+    class Vec2d_VecVecScaFixture : public testing::TestWithParam<std::tuple<Vec2d, Vec2d, double>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2d vectorOne, vectorTwo;
+        double expected;
+    };
+
+    // Vec2d operator / (double scalar) const
+    class Vec2d_DivideByScalarF : public Vec2d_VecScaVecFixture {};
+    TEST_P(Vec2d_DivideByScalarF, Vec2d_DivideByScalar)
+    {
+        Vec2d output = vector / scalar;
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_DivideByScalar, Vec2d_DivideByScalarF, testing::Values(
+        std::make_tuple(Vec2d(10.0, 20.0), 2.0, Vec2d(5.0, 10.0)),
+        std::make_tuple(Vec2d(-6.6, 4.4), -2.2, Vec2d(3.0, -2.0)),
+        std::make_tuple(Vec2d(10.0, -5.0), 2.0, Vec2d(5.0, -2.5)),
+        std::make_tuple(Vec2d(8.8, -7.7), 4.4, Vec2d(2.0, -1.75)),
+        std::make_tuple(Vec2d(9.0, 12.0), 3.0, Vec2d(3.0, 4.0))  // Additional test case
+    ));
+
+    // Vec2d operator / (const Vec2d& vector) const
+    class Vec2d_DivideByVectorF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_DivideByVectorF, Vec2d_DivideByVector)
+    {
+        Vec2d output = vectorOne / vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_DivideByVector, Vec2d_DivideByVectorF, testing::Values(
+        std::make_tuple(Vec2d(10.0, 20.0), Vec2d(2.0, 4.0), Vec2d(5.0, 5.0)),
+        std::make_tuple(Vec2d(-6.6, 4.4), Vec2d(-2.2, 2.2), Vec2d(3.0, 2.0)),
+        std::make_tuple(Vec2d(10.0, -5.0), Vec2d(2.0, -5.0), Vec2d(5.0, 1.0)),
+        std::make_tuple(Vec2d(8.8, -7.7), Vec2d(4.4, -7.7), Vec2d(2.0, 1.0))
+    ));
+
+    // void operator /= (const Vec2d& vector)
+    class Vec2d_DivideEqualsByVectorF : public Vec2d_VecVecVecFixture {};
+    TEST_P(Vec2d_DivideEqualsByVectorF, Vec2d_DivideEqualsByVector)
+    {
+        vectorOne /= vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
+        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_DivideEqualsByVector, Vec2d_DivideEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec2d(10.0, 20.0), Vec2d(2.0, 4.0), Vec2d(5.0, 5.0)),
+        std::make_tuple(Vec2d(-6.6, 4.4), Vec2d(-2.2, 2.2), Vec2d(3.0, 2.0)),
+        std::make_tuple(Vec2d(10.0, -5.0), Vec2d(2.0, -5.0), Vec2d(5.0, 1.0)),
+        std::make_tuple(Vec2d(8.8, -7.7), Vec2d(4.4, -7.7), Vec2d(2.0, 1.0))
+    ));
+
+    // void operator /= (double scalar)
+    class Vec2d_DivideEqualsByScalarF : public Vec2d_VecScaVecFixture {};
+    TEST_P(Vec2d_DivideEqualsByScalarF, Vec2d_DivideEqualsByScalar)
+    {
+        vector /= scalar;
+        ASSERT_DOUBLE_EQ(expected.x, vector.x);
+        ASSERT_DOUBLE_EQ(expected.y, vector.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_DivideEqualsByScalar, Vec2d_DivideEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec2d(10.0, 20.0), 2.0, Vec2d(5.0, 10.0)),
+        std::make_tuple(Vec2d(-6.6, 4.4), -2.2, Vec2d(3.0, -2.0)),
+        std::make_tuple(Vec2d(10.0, -5.0), 2.0, Vec2d(5.0, -2.5)),
+        std::make_tuple(Vec2d(8.8, -7.7), 4.4, Vec2d(2.0, -1.75)),
+        std::make_tuple(Vec2d(9.0, 12.0), 3.0, Vec2d(3.0, 4.0))  // Additional test case
+    ));
 }

--- a/test/Vec2d_Test.cpp
+++ b/test/Vec2d_Test.cpp
@@ -216,6 +216,53 @@ namespace Vec2d_Tests
         double expected;
     };
 
+    // float mag() const
+    class Vec2d_MagnitudeF : public Vec2d_VecVecScaFixture {};
+    TEST_P(Vec2d_MagnitudeF, Vec2d_Magnitude)
+    {
+        double output = vectorOne.mag();
+        std::cout << output << std::endl;
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_Magnitude, Vec2d_MagnitudeF, testing::Values(
+        std::make_tuple(Vec2d(5., 4.), Vec2d(0., 0.), 6.40312424),
+        std::make_tuple(Vec2d(-8.2, 0.6), Vec2d(0., 0.), 8.221922),
+        std::make_tuple(Vec2d(-8.2, -0.6), Vec2d(0., 0.), 8.221922)
+    ));
+
+    // float mag() const
+    class Vec2d_MagnitudeVectorF : public Vec2d_VecVecScaFixture {};
+    TEST_P(Vec2d_MagnitudeVectorF, Vec2d_MagnitudeVector)
+    {
+        double output = vectorOne.mag(vectorTwo);
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_MagnitudeVector, Vec2d_MagnitudeVectorF, testing::Values(
+        std::make_tuple(Vec2d(5., 4.), Vec2d(0., 0.), 6.40312423),
+        std::make_tuple(Vec2d(0., 0.), Vec2d(5., 4.), 6.40312423),
+        std::make_tuple(Vec2d(-8.2, 0.6), Vec2d(5.9, 4.6), 14.656398),
+        std::make_tuple(Vec2d(-8.2, -0.6), Vec2d(-5.9, -4.6), 4.61410880)
+    ));
+
+    // Vec2d rotate(double scalar)
+    class Vec2d_RotateF : public Vec2d_VecScaVecFixture {};
+    TEST_P(Vec2d_RotateF, Vec2d_Rotate)
+    {
+        Vec2d output = vector.rotate(scalar);
+        ASSERT_NEAR(expected.x, output.x, 1E-06);
+        ASSERT_NEAR(expected.y, output.y, 1E-06);
+    } 
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_Rotate, Vec2d_RotateF, testing::Values(
+        std::make_tuple(Vec2d(5., 5.), 0., Vec2d(5., 5.)),
+        std::make_tuple(Vec2d(5., 0.), 90., Vec2d(0., 5.)),
+        std::make_tuple(Vec2d(5., 0.), 270., Vec2d(0., -5.)),
+        std::make_tuple(Vec2d(5., 0.), 180., Vec2d(-5., 0.))
+    ));
+
+
     // Vec2d operator / (double scalar) const
     class Vec2d_DivideByScalarF : public Vec2d_VecScaVecFixture {};
     TEST_P(Vec2d_DivideByScalarF, Vec2d_DivideByScalar)
@@ -280,5 +327,99 @@ namespace Vec2d_Tests
         std::make_tuple(Vec2d(-6.6, 4.4), Vec2d(-2.2, 2.2), Vec2d(3.0, 2.0)),
         std::make_tuple(Vec2d(10.0, -5.0), Vec2d(2.0, -5.0), Vec2d(5.0, 1.0)),
         std::make_tuple(Vec2d(8.8, -7.7), Vec2d(4.4, -7.7), Vec2d(2.0, 1.0))
+    ));
+
+    // double Vec2d::dot(const Vec2d& vector) const
+    class Vec2d_DotVectorF : public Vec2d_VecVecScaFixture {};
+    TEST_P(Vec2d_DotVectorF, Vec2d_DotVector)
+    {
+        double output = vectorOne.dot(vectorTwo);
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_DotVector, Vec2d_DotVectorF, testing::Values(
+        std::make_tuple(Vec2d(5., 0.), Vec2d(0., 4.), 0.),
+        std::make_tuple(Vec2d(5., 4.), Vec2d(6.2, 10.2), 71.8),
+        std::make_tuple(Vec2d(-5, 4.), Vec2d(-6.2, -10.2), -9.8),
+        std::make_tuple(Vec2d(-5., 0.), Vec2d(-10.2, 4.), 51.)
+    ));
+
+    // double Vec2d::dot(double scalar) const
+    class Vec2d_DotScalarF : public Vec2d_VecVecScaFixture {};
+    TEST_P(Vec2d_DotScalarF, Vec2d_DotScalar)
+    {
+        double output = vectorOne.dot(vectorTwo.x);
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_DotScalar, Vec2d_DotScalarF, testing::Values(
+        std::make_tuple(Vec2d(5., 4.), Vec2d(6.2, 0.), 55.8),
+        std::make_tuple(Vec2d(-5., -4.), Vec2d(-6.2, 0.), 55.8),
+        std::make_tuple(Vec2d(-5., 4.), Vec2d(6.2, 0.),  -6.2),
+        std::make_tuple(Vec2d(5., -4.), Vec2d(6.2, 0.),  6.2)
+    ));
+
+    // double Vec2d::dot(double xTwo, double yTwo) const
+    class Vec2d_DotScalarScalarF : public Vec2d_VecVecScaFixture {};
+    TEST_P(Vec2d_DotScalarScalarF, Vec2d_DotScalarScalar)
+    {
+        double output = vectorOne.dot(vectorTwo.x, vectorTwo.y);
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_DotScalarScalar, Vec2d_DotScalarScalarF, testing::Values(
+        std::make_tuple(Vec2d(5., 0.), Vec2d(0., 4.), 0.),
+        std::make_tuple(Vec2d(5., 4.), Vec2d(6.2, 10.2), 71.8),
+        std::make_tuple(Vec2d(-5, 4.), Vec2d(-6.2, -10.2), -9.8),
+        std::make_tuple(Vec2d(-5., 0.), Vec2d(-10.2, 4.), 51.)
+    ));
+
+        class Vec2d_VecFloatFloatFixture : public testing::TestWithParam<std::tuple<Vec2d, float, float>>
+    {
+        protected:
+            void SetUp() override
+            {
+                vector = std::get<0>(GetParam());
+                expectedX = std::get<1>(GetParam());
+                expectedY = std::get<2>(GetParam());
+            }
+            Vec2d vector;
+            float expectedX, expectedY;
+    };
+
+    // Vec2d Vec2d::toFloat() const
+    class Vec2d_ConvertToFloatF : public Vec2d_VecFloatFloatFixture {};
+    TEST_P(Vec2d_ConvertToFloatF, Vec2f_ConvertToFloat)
+    { 
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().x));
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().y));   
+        ASSERT_NEAR(expectedX, vector.toFloat().x, 1E-05);
+        ASSERT_NEAR(expectedY, vector.toFloat().y, 1E-05);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_ConvertToFloat, Vec2d_ConvertToFloatF, testing::Values(
+        std::make_tuple(Vec2d(0., 0.), 0., 0.),
+        std::make_tuple(Vec2d(5.2, 5.2), 5.2, 5.2),
+        std::make_tuple(Vec2d(-5.2, -5.2), -5.2, -5.2),
+        std::make_tuple(Vec2d(10.09, -10.09), 10.09, -10.09)
+    ));
+
+    // Vec2d Vec2d::toDouble() const
+    class Vec2d_ConvertToDoubleF : public Vec2d_VecFloatFloatFixture {};
+    TEST_P(Vec2d_ConvertToDoubleF, Vec2d_ConvertToDouble)
+    { 
+        double expectX = (double)expectedX;
+        double expectY = (double)expectedY;
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().x));
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().y));   
+        ASSERT_NEAR(expectX, vector.toDouble().x, 1E-05);
+        ASSERT_NEAR(expectY, vector.toDouble().y, 1E-05);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2d_ConvertToDouble, Vec2d_ConvertToDoubleF, testing::Values(
+        std::make_tuple(Vec2d(0., 0.), 0., 0.),
+        std::make_tuple(Vec2d(5.2, 5.2), 5.2, 5.2),
+        std::make_tuple(Vec2d(-5.2, -5.2), -5.2, -5.2),
+        std::make_tuple(Vec2d(10.09, -10.09), 10.09, -10.09)
     ));
 }

--- a/test/Vec2f_Test.cpp
+++ b/test/Vec2f_Test.cpp
@@ -202,4 +202,85 @@ namespace Vec2d_Tests
         std::make_tuple(Vec2f(-5.5f, 5.5f), Vec2f(5.5f, -5.5f), false),
         std::make_tuple(Vec2f(6.1f, 0.0f), Vec2f(7.1f, 0.0f), false)
     ));
+
+    class Vec2f_VecVecScaFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, float>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2f vectorOne, vectorTwo;
+        float expected;
+    };
+
+    // Vec2f operator / (float scalar) const
+    class Vec2f_DivideByScalarF : public Vec2f_VecScaVecFixture {};
+    TEST_P(Vec2f_DivideByScalarF, Vec2f_DivideByScalar)
+    {
+        Vec2f output = vector / scalar;
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_DivideByScalar, Vec2f_DivideByScalarF, testing::Values(
+        std::make_tuple(Vec2f(10.0f, 20.0f), 2.0f, Vec2f(5.0f, 10.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), -2.2f, Vec2f(3.0f, -2.0f)),
+        std::make_tuple(Vec2f(10.0f, -5.0f), 2.0f, Vec2f(5.0f, -2.5f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), 4.4f, Vec2f(2.0f, -1.75f)),
+        std::make_tuple(Vec2f(9.0f, 12.0f), 3.0f, Vec2f(3.0f, 4.0f))  
+    ));
+
+    // Vec2f operator / (const Vec2f& vector) const
+    class Vec2f_DivideByVectorF : public Vec2f_VecVecVecFixture {};
+    TEST_P(Vec2f_DivideByVectorF, Vec2f_DivideByVector)
+    {
+        Vec2f output = vectorOne / vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_DivideByVector, Vec2f_DivideByVectorF, testing::Values(
+        std::make_tuple(Vec2f(10.0f, 20.0f), Vec2f(2.0f, 4.0f), Vec2f(5.0f, 5.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(-2.2f, 2.2f), Vec2f(3.0f, 2.0f)),
+        std::make_tuple(Vec2f(10.0f, -5.0f), Vec2f(2.0f, -5.0f), Vec2f(5.0f, 1.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), Vec2f(4.4f, -7.7f), Vec2f(2.0f, 1.0f))
+    ));
+
+    // void operator /= (float scalar)
+    class Vec2f_DivideEqualsByScalarF : public Vec2f_VecScaVecFixture {};
+    TEST_P(Vec2f_DivideEqualsByScalarF, Vec2f_DivideEqualsByScalar)
+    {
+        vector /= scalar;
+        ASSERT_FLOAT_EQ(expected.x, vector.x);
+        ASSERT_FLOAT_EQ(expected.y, vector.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_DivideEqualsByScalar, Vec2f_DivideEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec2f(10.0f, 20.0f), 2.0f, Vec2f(5.0f, 10.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), -2.2f, Vec2f(3.0f, -2.0f)),
+        std::make_tuple(Vec2f(10.0f, -5.0f), 2.0f, Vec2f(5.0f, -2.5f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), 4.4f, Vec2f(2.0f, -1.75f))
+    ));
+
+    // void operator /= (const Vec2f& vector)
+    class Vec2f_DivideEqualsByVectorF : public Vec2f_VecVecVecFixture {};
+    TEST_P(Vec2f_DivideEqualsByVectorF, Vec2f_DivideEqualsByVector)
+    {
+        vectorOne /= vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, vectorOne.x);
+        ASSERT_FLOAT_EQ(expected.y, vectorOne.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_DivideEqualsByVector, Vec2f_DivideEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec2f(10.0f, 20.0f), Vec2f(2.0f, 4.0f), Vec2f(5.0f, 5.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(-2.2f, 2.2f), Vec2f(3.0f, 2.0f)),
+        std::make_tuple(Vec2f(10.0f, -5.0f), Vec2f(2.0f, -5.0f), Vec2f(5.0f, 1.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), Vec2f(4.4f, -7.7f), Vec2f(2.0f, 1.0f))
+    ));
+
+
+
 }

--- a/test/Vec2f_Test.cpp
+++ b/test/Vec2f_Test.cpp
@@ -216,6 +216,51 @@ namespace Vec2d_Tests
         float expected;
     };
 
+    // float mag() const
+    class Vec2f_MagnitudeF : public Vec2f_VecVecScaFixture {};
+    TEST_P(Vec2f_MagnitudeF, Vec2f_Magnitude)
+    {
+        float output = vectorOne.mag();
+        ASSERT_FLOAT_EQ(expected, output);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_Magnitude, Vec2f_MagnitudeF, testing::Values(
+        std::make_tuple(Vec2f(5.f, 4.f), Vec2f(0.f, 0.f), 6.40312423f),
+        std::make_tuple(Vec2f(-8.2f, 0.6f), Vec2f(0.f, 0.f), 8.221922f),
+        std::make_tuple(Vec2f(-8.2f, -0.6f), Vec2f(0.f, 0.f), 8.221922f)
+    ));
+
+    // float mag(const Vec2f& vector) const
+    class Vec2f_MagnitudeVectorF : public Vec2f_VecVecScaFixture {};
+    TEST_P(Vec2f_MagnitudeVectorF, Vec2f_MagnitudeVector)
+    {
+        float output = vectorOne.mag(vectorTwo);
+        ASSERT_FLOAT_EQ(expected, output);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_MagnitudeVector, Vec2f_MagnitudeVectorF, testing::Values(
+        std::make_tuple(Vec2f(5.f, 4.f), Vec2f(0.f, 0.f), 6.40312423f),
+        std::make_tuple(Vec2f(0.f, 0.f), Vec2f(5.f, 4.f), 6.40312423f),
+        std::make_tuple(Vec2f(-8.2f, 0.6f), Vec2f(5.9f, 4.6f), 14.656398f),
+        std::make_tuple(Vec2f(-8.2f, -0.6f), Vec2f(-5.9f, -4.6f), 4.61410880f)
+    ));
+
+    // Vec2f rotate(float scalar) const
+    class Vec2f_RotateF : public Vec2f_VecScaVecFixture {};
+    TEST_P(Vec2f_RotateF, Vec2f_Rotate)
+    {
+        Vec2f output = vector.rotate(scalar);
+        ASSERT_NEAR(expected.x, output.x, 1E-06);
+        ASSERT_NEAR(expected.y, output.y, 1E-06);
+    } 
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_Rotate, Vec2f_RotateF, testing::Values(
+        std::make_tuple(Vec2f(5.f, 5.f), 0.f, Vec2f(5.f, 5.f)),
+        std::make_tuple(Vec2f(5.f, 0.f), 90.f, Vec2f(0.f, 5.f)),
+        std::make_tuple(Vec2f(5.f, 0.f), 270.f, Vec2f(0.f, -5.f)),
+        std::make_tuple(Vec2f(5.f, 0.f), 180.f, Vec2f(-5.f, 0.f))
+    ));
+
     // Vec2f operator / (float scalar) const
     class Vec2f_DivideByScalarF : public Vec2f_VecScaVecFixture {};
     TEST_P(Vec2f_DivideByScalarF, Vec2f_DivideByScalar)
@@ -282,5 +327,83 @@ namespace Vec2d_Tests
     ));
 
 
+    // float Vec2f::dot(float scalar) const
+    class Vec2f_DotScalarF : public Vec2f_VecVecScaFixture {};
+    TEST_P(Vec2f_DotScalarF, Vec2f_DotScalar)
+    {
+        float output = vectorOne.dot(vectorTwo.x);
+        ASSERT_NEAR(expected, output, 1E-05);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_DotScalar, Vec2f_DotScalarF, testing::Values(
+        std::make_tuple(Vec2f(5.f, 4.f), Vec2f(6.2f, 0.f), 55.8f),
+        std::make_tuple(Vec2f(-5.f, -4.f), Vec2f(-6.2f, 0.f), 55.8f),
+        std::make_tuple(Vec2f(-5.f, 4.f), Vec2f(6.2f, 0.f),  -6.2f),
+        std::make_tuple(Vec2f(5.f, -4.f), Vec2f(6.2f, 0.f),  6.2f)
+    ));
+
+    // float Vec2f::dot(float xTwo, float yTwo) const
+    class Vec2f_DotScalarScalarF : public Vec2f_VecVecScaFixture {};
+    TEST_P(Vec2f_DotScalarScalarF, Vec2f_DotScalarScalar)
+    {
+        float output = vectorOne.dot(vectorTwo.x, vectorTwo.y);
+        ASSERT_NEAR(expected, output, 1E-05);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_DotScalarScalar, Vec2f_DotScalarScalarF, testing::Values(
+        std::make_tuple(Vec2f(5.f, 0.f), Vec2f(0.f, 4.f), 0.f),
+        std::make_tuple(Vec2f(5.f, 4.f), Vec2f(6.2f, 10.2f), 71.8f),
+        std::make_tuple(Vec2f(-5.f, 4.f), Vec2f(-6.2f, -10.2f), -9.8f),
+        std::make_tuple(Vec2f(-5.f, 0.f), Vec2f(-10.2f, 4.f), 51.f)
+    ));
+
+    class Vec2f_VecFloatFloatFixture : public testing::TestWithParam<std::tuple<Vec2f, float, float>>
+    {
+        protected:
+            void SetUp() override
+            {
+                vector = std::get<0>(GetParam());
+                expectedX = std::get<1>(GetParam());
+                expectedY = std::get<2>(GetParam());
+            }
+            Vec2f vector;
+            float expectedX, expectedY;
+    };
+
+    // Vec2f Vec2f::toFloat() const
+    class Vec2f_ConvertToFloatF : public Vec2f_VecFloatFloatFixture {};
+    TEST_P(Vec2f_ConvertToFloatF, Vec2f_ConvertToFloat)
+    { 
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().x));
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().y));   
+        ASSERT_EQ(expectedX, vector.toFloat().x);
+        ASSERT_EQ(expectedY, vector.toFloat().y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_ConvertToFloat, Vec2f_ConvertToFloatF, testing::Values(
+        std::make_tuple(Vec2f(0.f, 0.f), 0.f, 0.f),
+        std::make_tuple(Vec2f(5.2f, 5.2f), 5.2f, 5.2f),
+        std::make_tuple(Vec2f(-5.2f, -5.2f), -5.2f, -5.2f),
+        std::make_tuple(Vec2f(10.09f, -10.09f), 10.09f, -10.09f)
+    ));
+
+    // Vec2d Vec2f::toDouble() const
+    class Vec2f_ConvertToDoubleF : public Vec2f_VecFloatFloatFixture {};
+    TEST_P(Vec2f_ConvertToDoubleF, Vec2f_ConvertToDouble)
+    { 
+        double expectX = (double)expectedX;
+        double expectY = (double)expectedY;
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().x));
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().y));   
+        ASSERT_NEAR(expectX, vector.toDouble().x, 1E-05);
+        ASSERT_NEAR(expectY, vector.toDouble().y, 1E-05);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_ConvertToDouble, Vec2f_ConvertToDoubleF, testing::Values(
+        std::make_tuple(Vec2f(0.f, 0.f), 0.f, 0.f),
+        std::make_tuple(Vec2f(5.2f, 5.2f), 5.2f, 5.2f),
+        std::make_tuple(Vec2f(-5.2f, -5.2f), -5.2f, -5.2f),
+        std::make_tuple(Vec2f(10.09f, -10.09f), 10.09f, -10.09f)
+    ));
 
 }

--- a/test/Vec2f_Test.cpp
+++ b/test/Vec2f_Test.cpp
@@ -1,0 +1,400 @@
+#include "pch.h"
+#include <VecPlus/Vec2.h>
+#include <iostream>
+
+using namespace vecp;
+
+namespace Vec2d_Tests
+{
+    TEST(TestConstructorDefault, SetDefaultValues)
+    {   
+        Vec2f vector = Vec2f();
+        ASSERT_EQ(vector.x, 0.0f);
+        ASSERT_EQ(vector.y, 0.0f);
+    }
+
+    // Constructor with specified values test
+    TEST(TestConstructorValues, SetSpecifiedValues)
+    {
+        Vec2f vector = Vec2f(-3.5f, 4.2f);
+        ASSERT_EQ(vector.x, -3.5f);
+        ASSERT_EQ(vector.y, 4.2f);
+    }
+
+    class VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2f, float, Vec2f>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vector = std::get<0>(GetParam());
+            scalar = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2f vector, expected;
+        float scalar;
+    };
+
+    class VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, Vec2f>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2f vectorOne, vectorTwo, expected;
+    };
+
+    // Vec2f operator + (const Vec2f& vector) const
+    class AddVectorF : public VecVecVecFixture {};
+    TEST_P(AddVectorF, AddVector)
+    {
+        Vec2f output = vectorOne + vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(AddVector, AddVectorF, testing::Values(
+        std::make_tuple(Vec2f(1.1f, 2.2f), Vec2f(3.3f, 4.4f), Vec2f(4.4f, 6.6f)),
+        std::make_tuple(Vec2f(-2.5f, 5.1f), Vec2f(7.2f, -3.3f), Vec2f(4.7f, 1.8f)),
+        std::make_tuple(Vec2f(0.0f, -8.4f), Vec2f(-4.4f, 6.6f), Vec2f(-4.4f, -1.8f)),
+        std::make_tuple(Vec2f(10.0f, -10.0f), Vec2f(-10.0f, 10.0f), Vec2f(0.0f, 0.0f))
+    ));
+
+    // void operator += (const Vec2f& vector)
+    class AddEqualsVectorF : public VecVecVecFixture {};
+    TEST_P(AddEqualsVectorF, AddEqualsVector)
+    {
+        vectorOne += vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(AddEqualsVector, AddEqualsVectorF, testing::Values(
+        std::make_tuple(Vec2f(1.1f, 2.2f), Vec2f(3.3f, 4.4f), Vec2f(4.4f, 6.6f)),
+        std::make_tuple(Vec2f(-2.5f, 5.1f), Vec2f(7.2f, -3.3f), Vec2f(4.7f, 1.8f)),
+        std::make_tuple(Vec2f(0.0f, -8.4f), Vec2f(-4.4f, 6.6f), Vec2f(-4.4f, -1.8f)),
+        std::make_tuple(Vec2f(10.0f, -10.0f), Vec2f(-10.0f, 10.0f), Vec2f(0.0f, 0.0f))
+    ));
+
+    // Vec2f operator - (const Vec2f& vector) const
+    class SubtractVectorF : public VecVecVecFixture {};
+    TEST_P(SubtractVectorF, SubtractVector)
+    {
+        Vec2f output = vectorOne - vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(SubtractVector, SubtractVectorF, testing::Values(
+        std::make_tuple(Vec2f(5.5f, 7.7f), Vec2f(3.3f, 2.2f), Vec2f(2.2f, 5.5f)),
+        std::make_tuple(Vec2f(10.0f, 10.0f), Vec2f(4.5f, 6.5f), Vec2f(5.5f, 3.5f)),
+        std::make_tuple(Vec2f(-3.3f, 8.8f), Vec2f(2.2f, -5.5f), Vec2f(-5.5f, 14.3f)),
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(-7.7f, 9.9f), Vec2f(7.7f, -9.9f))
+    ));
+
+    // void operator -= (const Vec2f& vector)
+    class SubtractEqualsVectorF : public VecVecVecFixture {};
+    TEST_P(SubtractEqualsVectorF, SubtractEqualsVector)
+    {
+        vectorOne -= vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(SubtractEqualsVector, SubtractEqualsVectorF, testing::Values(
+        std::make_tuple(Vec2f(5.5f, 7.7f), Vec2f(3.3f, 2.2f), Vec2f(2.2f, 5.5f)),
+        std::make_tuple(Vec2f(10.0f, 10.0f), Vec2f(4.5f, 6.5f), Vec2f(5.5f, 3.5f)),
+        std::make_tuple(Vec2f(-3.3f, 8.8f), Vec2f(2.2f, -5.5f), Vec2f(-5.5f, 14.3f)),
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(-7.7f, 9.9f), Vec2f(7.7f, -9.9f))
+    ));
+
+    // Vec2f operator * (float scalar) const
+    class MultiplyByScalarF : public VecScaVecFixture {};
+    TEST_P(MultiplyByScalarF, MultiplyByScalar)
+    {
+        Vec2f output = vector * scalar;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyByScalar, MultiplyByScalarF, testing::Values(
+        std::make_tuple(Vec2f(0.0f, 0.0f), 10.0f, Vec2f(0.0f, 0.0f)),
+        std::make_tuple(Vec2f(3.3f, 4.4f), 10.0f, Vec2f(33.0f, 44.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), 5.0f, Vec2f(-33.0f, 22.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), -5.0f, Vec2f(-44.0f, 38.5f))
+    ));
+
+    // Vec2f operator * (const Vec2f& vector) const
+    class MultiplyByVectorF : public VecVecVecFixture {};
+    TEST_P(MultiplyByVectorF, MultiplyByVector)
+    {
+        Vec2f output = vectorOne * vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyByVector, MultiplyByVectorF, testing::Values(
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(10.0f, 10.0f), Vec2f(0.0f, 0.0f)),
+        std::make_tuple(Vec2f(3.3f, 4.4f), Vec2f(5.5f, 10.0f), Vec2f(18.15f, 44.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(5.5f, -5.0f), Vec2f(-36.3f, -22.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), Vec2f(-5.5f, -5.5f), Vec2f(-48.4f, 42.35f))
+    ));
+
+    // void operator *= (float scalar)
+    class MultiplyEqualsByScalarF : public VecScaVecFixture {};
+    TEST_P(MultiplyEqualsByScalarF, MultiplyEqualsByScalar)
+    {
+        vector *= scalar;
+        ASSERT_EQ(expected.x, vector.x);
+        ASSERT_EQ(expected.y, vector.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByScalar, MultiplyEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec2f(0.0f, 0.0f), 10.0f, Vec2f(0.0f, 0.0f)),
+        std::make_tuple(Vec2f(3.3f, 4.4f), 10.0f, Vec2f(33.0f, 44.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), 5.0f, Vec2f(-33.0f, 22.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), -5.0f, Vec2f(-44.0f, 38.5f))
+    ));
+
+    // void operator *= (const Vec2f& vector)
+    class MultiplyEqualsByVectorF : public VecVecVecFixture {};
+    TEST_P(MultiplyEqualsByVectorF, MultiplyEqualsByVector)
+    {
+        vectorOne *= vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByVector, MultiplyEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(10.0f, 10.0f), Vec2f(0.0f, 0.0f)),
+        std::make_tuple(Vec2f(3.3f, 4.4f), Vec2f(5.5f, 10.0f), Vec2f(18.15f, 44.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(5.5f, -5.0f), Vec2f(-36.3f, -22.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), Vec2f(-5.5f, -5.5f), Vec2f(-48.4f, 42.35f))
+    ));
+
+    class VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, bool>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2f vectorOne, vectorTwo;
+        bool expected;
+    };
+
+    // bool operator == (const Vec2f& vector) const
+    class CompareVectorsF : public VecVecBoolFixture {};
+    TEST_P(CompareVectorsF, CompareVectors)
+    {
+        bool output = vectorOne == vectorTwo;
+        ASSERT_EQ(expected, output);
+        ASSERT_EQ(expected, output);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(CompareVectors, CompareVectorsF, testing::Values(
+        std::make_tuple(Vec2f(-5.5f, 5.5f), Vec2f(-5.5f, 5.5f), true),
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(0.0f, 0.0f), true),
+        std::make_tuple(Vec2f(-5.5f, 5.5f), Vec2f(5.5f, -5.5f), false),
+        std::make_tuple(Vec2f(6.1f, 0.0f), Vec2f(7.1f, 0.0f), false)
+    ));TEST(TestConstructorDefault, SetDefaultValues)
+    {   
+        Vec2f vector = Vec2f();
+        ASSERT_EQ(vector.x, 0.0f);
+        ASSERT_EQ(vector.y, 0.0f);
+    }
+
+    // Constructor with specified values test
+    TEST(TestConstructorValues, SetSpecifiedValues)
+    {
+        Vec2f vector = Vec2f(-3.5f, 4.2f);
+        ASSERT_EQ(vector.x, -3.5f);
+        ASSERT_EQ(vector.y, 4.2f);
+    }
+
+    class VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2f, float, Vec2f>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vector = std::get<0>(GetParam());
+            scalar = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2f vector, expected;
+        float scalar;
+    };
+
+    class VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, Vec2f>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2f vectorOne, vectorTwo, expected;
+    };
+
+    // Vec2f operator + (const Vec2f& vector) const
+    class AddVectorF : public VecVecVecFixture {};
+    TEST_P(AddVectorF, AddVector)
+    {
+        Vec2f output = vectorOne + vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(AddVector, AddVectorF, testing::Values(
+        std::make_tuple(Vec2f(1.1f, 2.2f), Vec2f(3.3f, 4.4f), Vec2f(4.4f, 6.6f)),
+        std::make_tuple(Vec2f(-2.5f, 5.1f), Vec2f(7.2f, -3.3f), Vec2f(4.7f, 1.8f)),
+        std::make_tuple(Vec2f(0.0f, -8.4f), Vec2f(-4.4f, 6.6f), Vec2f(-4.4f, -1.8f)),
+        std::make_tuple(Vec2f(10.0f, -10.0f), Vec2f(-10.0f, 10.0f), Vec2f(0.0f, 0.0f))
+    ));
+
+    // void operator += (const Vec2f& vector)
+    class AddEqualsVectorF : public VecVecVecFixture {};
+    TEST_P(AddEqualsVectorF, AddEqualsVector)
+    {
+        vectorOne += vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(AddEqualsVector, AddEqualsVectorF, testing::Values(
+        std::make_tuple(Vec2f(1.1f, 2.2f), Vec2f(3.3f, 4.4f), Vec2f(4.4f, 6.6f)),
+        std::make_tuple(Vec2f(-2.5f, 5.1f), Vec2f(7.2f, -3.3f), Vec2f(4.7f, 1.8f)),
+        std::make_tuple(Vec2f(0.0f, -8.4f), Vec2f(-4.4f, 6.6f), Vec2f(-4.4f, -1.8f)),
+        std::make_tuple(Vec2f(10.0f, -10.0f), Vec2f(-10.0f, 10.0f), Vec2f(0.0f, 0.0f))
+    ));
+
+    // Vec2f operator - (const Vec2f& vector) const
+    class SubtractVectorF : public VecVecVecFixture {};
+    TEST_P(SubtractVectorF, SubtractVector)
+    {
+        Vec2f output = vectorOne - vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(SubtractVector, SubtractVectorF, testing::Values(
+        std::make_tuple(Vec2f(5.5f, 7.7f), Vec2f(3.3f, 2.2f), Vec2f(2.2f, 5.5f)),
+        std::make_tuple(Vec2f(10.0f, 10.0f), Vec2f(4.5f, 6.5f), Vec2f(5.5f, 3.5f)),
+        std::make_tuple(Vec2f(-3.3f, 8.8f), Vec2f(2.2f, -5.5f), Vec2f(-5.5f, 14.3f)),
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(-7.7f, 9.9f), Vec2f(7.7f, -9.9f))
+    ));
+
+    // void operator -= (const Vec2f& vector)
+    class SubtractEqualsVectorF : public VecVecVecFixture {};
+    TEST_P(SubtractEqualsVectorF, SubtractEqualsVector)
+    {
+        vectorOne -= vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(SubtractEqualsVector, SubtractEqualsVectorF, testing::Values(
+        std::make_tuple(Vec2f(5.5f, 7.7f), Vec2f(3.3f, 2.2f), Vec2f(2.2f, 5.5f)),
+        std::make_tuple(Vec2f(10.0f, 10.0f), Vec2f(4.5f, 6.5f), Vec2f(5.5f, 3.5f)),
+        std::make_tuple(Vec2f(-3.3f, 8.8f), Vec2f(2.2f, -5.5f), Vec2f(-5.5f, 14.3f)),
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(-7.7f, 9.9f), Vec2f(7.7f, -9.9f))
+    ));
+
+    // Vec2f operator * (float scalar) const
+    class MultiplyByScalarF : public VecScaVecFixture {};
+    TEST_P(MultiplyByScalarF, MultiplyByScalar)
+    {
+        Vec2f output = vector * scalar;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyByScalar, MultiplyByScalarF, testing::Values(
+        std::make_tuple(Vec2f(0.0f, 0.0f), 10.0f, Vec2f(0.0f, 0.0f)),
+        std::make_tuple(Vec2f(3.3f, 4.4f), 10.0f, Vec2f(33.0f, 44.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), 5.0f, Vec2f(-33.0f, 22.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), -5.0f, Vec2f(-44.0f, 38.5f))
+    ));
+
+    // Vec2f operator * (const Vec2f& vector) const
+    class MultiplyByVectorF : public VecVecVecFixture {};
+    TEST_P(MultiplyByVectorF, MultiplyByVector)
+    {
+        Vec2f output = vectorOne * vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyByVector, MultiplyByVectorF, testing::Values(
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(10.0f, 10.0f), Vec2f(0.0f, 0.0f)),
+        std::make_tuple(Vec2f(3.3f, 4.4f), Vec2f(5.5f, 10.0f), Vec2f(18.15f, 44.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(5.5f, -5.0f), Vec2f(-36.3f, -22.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), Vec2f(-5.5f, -5.5f), Vec2f(-48.4f, 42.35f))
+    ));
+
+    // void operator *= (float scalar)
+    class MultiplyEqualsByScalarF : public VecScaVecFixture {};
+    TEST_P(MultiplyEqualsByScalarF, MultiplyEqualsByScalar)
+    {
+        vector *= scalar;
+        ASSERT_EQ(expected.x, vector.x);
+        ASSERT_EQ(expected.y, vector.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByScalar, MultiplyEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec2f(0.0f, 0.0f), 10.0f, Vec2f(0.0f, 0.0f)),
+        std::make_tuple(Vec2f(3.3f, 4.4f), 10.0f, Vec2f(33.0f, 44.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), 5.0f, Vec2f(-33.0f, 22.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), -5.0f, Vec2f(-44.0f, 38.5f))
+    ));
+
+    // void operator *= (const Vec2f& vector)
+    class MultiplyEqualsByVectorF : public VecVecVecFixture {};
+    TEST_P(MultiplyEqualsByVectorF, MultiplyEqualsByVector)
+    {
+        vectorOne *= vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByVector, MultiplyEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(10.0f, 10.0f), Vec2f(0.0f, 0.0f)),
+        std::make_tuple(Vec2f(3.3f, 4.4f), Vec2f(5.5f, 10.0f), Vec2f(18.15f, 44.0f)),
+        std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(5.5f, -5.0f), Vec2f(-36.3f, -22.0f)),
+        std::make_tuple(Vec2f(8.8f, -7.7f), Vec2f(-5.5f, -5.5f), Vec2f(-48.4f, 42.35f))
+    ));
+
+    class VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, bool>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec2f vectorOne, vectorTwo;
+        bool expected;
+    };
+
+    // bool operator == (const Vec2f& vector) const
+    class CompareVectorsF : public VecVecBoolFixture {};
+    TEST_P(CompareVectorsF, CompareVectors)
+    {
+        bool output = vectorOne == vectorTwo;
+        ASSERT_EQ(expected, output);
+        ASSERT_EQ(expected, output);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(CompareVectors, CompareVectorsF, testing::Values(
+        std::make_tuple(Vec2f(-5.5f, 5.5f), Vec2f(-5.5f, 5.5f), true),
+        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(0.0f, 0.0f), true),
+        std::make_tuple(Vec2f(-5.5f, 5.5f), Vec2f(5.5f, -5.5f), false),
+        std::make_tuple(Vec2f(6.1f, 0.0f), Vec2f(7.1f, 0.0f), false)
+    ));
+}

--- a/test/Vec2f_Test.cpp
+++ b/test/Vec2f_Test.cpp
@@ -6,22 +6,22 @@ using namespace vecp;
 
 namespace Vec2d_Tests
 {
-    TEST(TestConstructorDefault, SetDefaultValues)
+    TEST(Vec2f_TestConstructorDefault, SetDefaultValues)
     {   
         Vec2f vector = Vec2f();
-        ASSERT_EQ(vector.x, 0.0f);
-        ASSERT_EQ(vector.y, 0.0f);
+        ASSERT_FLOAT_EQ(vector.x, 0.0f);
+        ASSERT_FLOAT_EQ(vector.y, 0.0f);
     }
 
     // Constructor with specified values test
-    TEST(TestConstructorValues, SetSpecifiedValues)
+    TEST(Vec2f_TestConstructorValues, SetSpecifiedValues)
     {
         Vec2f vector = Vec2f(-3.5f, 4.2f);
-        ASSERT_EQ(vector.x, -3.5f);
-        ASSERT_EQ(vector.y, 4.2f);
+        ASSERT_FLOAT_EQ(vector.x, -3.5f);
+        ASSERT_FLOAT_EQ(vector.y, 4.2f);
     }
 
-    class VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2f, float, Vec2f>>
+    class Vec2f_VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2f, float, Vec2f>>
     {
     protected:
         void SetUp() override
@@ -34,7 +34,7 @@ namespace Vec2d_Tests
         float scalar;
     };
 
-    class VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, Vec2f>>
+    class Vec2f_VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, Vec2f>>
     {
     protected:
         void SetUp() override
@@ -47,15 +47,15 @@ namespace Vec2d_Tests
     };
 
     // Vec2f operator + (const Vec2f& vector) const
-    class AddVectorF : public VecVecVecFixture {};
-    TEST_P(AddVectorF, AddVector)
+    class Vec2f_AddVectorF : public Vec2f_VecVecVecFixture {};
+    TEST_P(Vec2f_AddVectorF, Vec2f_AddVector)
     {
         Vec2f output = vectorOne + vectorTwo;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(AddVector, AddVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2f_AddVector, Vec2f_AddVectorF, testing::Values(
         std::make_tuple(Vec2f(1.1f, 2.2f), Vec2f(3.3f, 4.4f), Vec2f(4.4f, 6.6f)),
         std::make_tuple(Vec2f(-2.5f, 5.1f), Vec2f(7.2f, -3.3f), Vec2f(4.7f, 1.8f)),
         std::make_tuple(Vec2f(0.0f, -8.4f), Vec2f(-4.4f, 6.6f), Vec2f(-4.4f, -1.8f)),
@@ -63,15 +63,15 @@ namespace Vec2d_Tests
     ));
 
     // void operator += (const Vec2f& vector)
-    class AddEqualsVectorF : public VecVecVecFixture {};
-    TEST_P(AddEqualsVectorF, AddEqualsVector)
+    class Vec2f_AddEqualsVectorF : public Vec2f_VecVecVecFixture {};
+    TEST_P(Vec2f_AddEqualsVectorF, Vec2f_AddEqualsVector)
     {
         vectorOne += vectorTwo;
-        ASSERT_EQ(expected.x, vectorOne.x);
-        ASSERT_EQ(expected.y, vectorOne.y);
+        ASSERT_FLOAT_EQ(expected.x, vectorOne.x);
+        ASSERT_FLOAT_EQ(expected.y, vectorOne.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(AddEqualsVector, AddEqualsVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2f_AddEqualsVector, Vec2f_AddEqualsVectorF, testing::Values(
         std::make_tuple(Vec2f(1.1f, 2.2f), Vec2f(3.3f, 4.4f), Vec2f(4.4f, 6.6f)),
         std::make_tuple(Vec2f(-2.5f, 5.1f), Vec2f(7.2f, -3.3f), Vec2f(4.7f, 1.8f)),
         std::make_tuple(Vec2f(0.0f, -8.4f), Vec2f(-4.4f, 6.6f), Vec2f(-4.4f, -1.8f)),
@@ -79,15 +79,15 @@ namespace Vec2d_Tests
     ));
 
     // Vec2f operator - (const Vec2f& vector) const
-    class SubtractVectorF : public VecVecVecFixture {};
-    TEST_P(SubtractVectorF, SubtractVector)
+    class Vec2f_SubtractVectorF : public Vec2f_VecVecVecFixture {};
+    TEST_P(Vec2f_SubtractVectorF, Vec2f_SubtractVector)
     {
         Vec2f output = vectorOne - vectorTwo;
         ASSERT_EQ(expected.x, output.x);
         ASSERT_EQ(expected.y, output.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(SubtractVector, SubtractVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2f_SubtractVector, Vec2f_SubtractVectorF, testing::Values(
         std::make_tuple(Vec2f(5.5f, 7.7f), Vec2f(3.3f, 2.2f), Vec2f(2.2f, 5.5f)),
         std::make_tuple(Vec2f(10.0f, 10.0f), Vec2f(4.5f, 6.5f), Vec2f(5.5f, 3.5f)),
         std::make_tuple(Vec2f(-3.3f, 8.8f), Vec2f(2.2f, -5.5f), Vec2f(-5.5f, 14.3f)),
@@ -95,15 +95,15 @@ namespace Vec2d_Tests
     ));
 
     // void operator -= (const Vec2f& vector)
-    class SubtractEqualsVectorF : public VecVecVecFixture {};
-    TEST_P(SubtractEqualsVectorF, SubtractEqualsVector)
+    class Vec2f_SubtractEqualsVectorF : public Vec2f_VecVecVecFixture {};
+    TEST_P(Vec2f_SubtractEqualsVectorF, Vec2f_SubtractEqualsVector)
     {
         vectorOne -= vectorTwo;
-        ASSERT_EQ(expected.x, vectorOne.x);
-        ASSERT_EQ(expected.y, vectorOne.y);
+        ASSERT_FLOAT_EQ(expected.x, vectorOne.x);
+        ASSERT_FLOAT_EQ(expected.y, vectorOne.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(SubtractEqualsVector, SubtractEqualsVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2f_SubtractEqualsVector, Vec2f_SubtractEqualsVectorF, testing::Values(
         std::make_tuple(Vec2f(5.5f, 7.7f), Vec2f(3.3f, 2.2f), Vec2f(2.2f, 5.5f)),
         std::make_tuple(Vec2f(10.0f, 10.0f), Vec2f(4.5f, 6.5f), Vec2f(5.5f, 3.5f)),
         std::make_tuple(Vec2f(-3.3f, 8.8f), Vec2f(2.2f, -5.5f), Vec2f(-5.5f, 14.3f)),
@@ -111,15 +111,15 @@ namespace Vec2d_Tests
     ));
 
     // Vec2f operator * (float scalar) const
-    class MultiplyByScalarF : public VecScaVecFixture {};
-    TEST_P(MultiplyByScalarF, MultiplyByScalar)
+    class Vec2f_MultiplyByScalarF : public Vec2f_VecScaVecFixture {};
+    TEST_P(Vec2f_MultiplyByScalarF, Vec2f_MultiplyByScalar)
     {
         Vec2f output = vector * scalar;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);   
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyByScalar, MultiplyByScalarF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2f_MultiplyByScalar, Vec2f_MultiplyByScalarF, testing::Values(
         std::make_tuple(Vec2f(0.0f, 0.0f), 10.0f, Vec2f(0.0f, 0.0f)),
         std::make_tuple(Vec2f(3.3f, 4.4f), 10.0f, Vec2f(33.0f, 44.0f)),
         std::make_tuple(Vec2f(-6.6f, 4.4f), 5.0f, Vec2f(-33.0f, 22.0f)),
@@ -127,15 +127,15 @@ namespace Vec2d_Tests
     ));
 
     // Vec2f operator * (const Vec2f& vector) const
-    class MultiplyByVectorF : public VecVecVecFixture {};
-    TEST_P(MultiplyByVectorF, MultiplyByVector)
+    class Vec2f_MultiplyByVectorF : public Vec2f_VecVecVecFixture {};
+    TEST_P(Vec2f_MultiplyByVectorF, Vec2f_MultiplyByVector)
     {
         Vec2f output = vectorOne * vectorTwo;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);   
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyByVector, MultiplyByVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2f_MultiplyByVector, Vec2f_MultiplyByVectorF, testing::Values(
         std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(10.0f, 10.0f), Vec2f(0.0f, 0.0f)),
         std::make_tuple(Vec2f(3.3f, 4.4f), Vec2f(5.5f, 10.0f), Vec2f(18.15f, 44.0f)),
         std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(5.5f, -5.0f), Vec2f(-36.3f, -22.0f)),
@@ -143,15 +143,15 @@ namespace Vec2d_Tests
     ));
 
     // void operator *= (float scalar)
-    class MultiplyEqualsByScalarF : public VecScaVecFixture {};
-    TEST_P(MultiplyEqualsByScalarF, MultiplyEqualsByScalar)
+    class Vec2f_MultiplyEqualsByScalarF : public Vec2f_VecScaVecFixture {};
+    TEST_P(Vec2f_MultiplyEqualsByScalarF, Vec2f_MultiplyEqualsByScalar)
     {
         vector *= scalar;
-        ASSERT_EQ(expected.x, vector.x);
-        ASSERT_EQ(expected.y, vector.y);   
+        ASSERT_FLOAT_EQ(expected.x, vector.x);
+        ASSERT_FLOAT_EQ(expected.y, vector.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByScalar, MultiplyEqualsByScalarF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2f_MultiplyEqualsByScalar,Vec2f_MultiplyEqualsByScalarF, testing::Values(
         std::make_tuple(Vec2f(0.0f, 0.0f), 10.0f, Vec2f(0.0f, 0.0f)),
         std::make_tuple(Vec2f(3.3f, 4.4f), 10.0f, Vec2f(33.0f, 44.0f)),
         std::make_tuple(Vec2f(-6.6f, 4.4f), 5.0f, Vec2f(-33.0f, 22.0f)),
@@ -159,22 +159,22 @@ namespace Vec2d_Tests
     ));
 
     // void operator *= (const Vec2f& vector)
-    class MultiplyEqualsByVectorF : public VecVecVecFixture {};
-    TEST_P(MultiplyEqualsByVectorF, MultiplyEqualsByVector)
+    class Vec2f_MultiplyEqualsByVectorF : public Vec2f_VecVecVecFixture {};
+    TEST_P(Vec2f_MultiplyEqualsByVectorF, MultiplyEqualsByVector)
     {
         vectorOne *= vectorTwo;
-        ASSERT_EQ(expected.x, vectorOne.x);
-        ASSERT_EQ(expected.y, vectorOne.y);   
+        ASSERT_FLOAT_EQ(expected.x, vectorOne.x);
+        ASSERT_FLOAT_EQ(expected.y, vectorOne.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByVector, MultiplyEqualsByVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2f_MultiplyEqualsByVector, Vec2f_MultiplyEqualsByVectorF, testing::Values(
         std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(10.0f, 10.0f), Vec2f(0.0f, 0.0f)),
         std::make_tuple(Vec2f(3.3f, 4.4f), Vec2f(5.5f, 10.0f), Vec2f(18.15f, 44.0f)),
         std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(5.5f, -5.0f), Vec2f(-36.3f, -22.0f)),
         std::make_tuple(Vec2f(8.8f, -7.7f), Vec2f(-5.5f, -5.5f), Vec2f(-48.4f, 42.35f))
     ));
 
-    class VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, bool>>
+    class Vec2f_VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, bool>>
     {
     protected:
         void SetUp() override
@@ -188,210 +188,15 @@ namespace Vec2d_Tests
     };
 
     // bool operator == (const Vec2f& vector) const
-    class CompareVectorsF : public VecVecBoolFixture {};
-    TEST_P(CompareVectorsF, CompareVectors)
+    class Vec2f_CompareVectorsF : public Vec2f_VecVecBoolFixture {};
+    TEST_P(Vec2f_CompareVectorsF, CompareVectors)
     {
         bool output = vectorOne == vectorTwo;
-        ASSERT_EQ(expected, output);
-        ASSERT_EQ(expected, output);   
+        ASSERT_FLOAT_EQ(expected, output);
+        ASSERT_FLOAT_EQ(expected, output);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(CompareVectors, CompareVectorsF, testing::Values(
-        std::make_tuple(Vec2f(-5.5f, 5.5f), Vec2f(-5.5f, 5.5f), true),
-        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(0.0f, 0.0f), true),
-        std::make_tuple(Vec2f(-5.5f, 5.5f), Vec2f(5.5f, -5.5f), false),
-        std::make_tuple(Vec2f(6.1f, 0.0f), Vec2f(7.1f, 0.0f), false)
-    ));TEST(TestConstructorDefault, SetDefaultValues)
-    {   
-        Vec2f vector = Vec2f();
-        ASSERT_EQ(vector.x, 0.0f);
-        ASSERT_EQ(vector.y, 0.0f);
-    }
-
-    // Constructor with specified values test
-    TEST(TestConstructorValues, SetSpecifiedValues)
-    {
-        Vec2f vector = Vec2f(-3.5f, 4.2f);
-        ASSERT_EQ(vector.x, -3.5f);
-        ASSERT_EQ(vector.y, 4.2f);
-    }
-
-    class VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2f, float, Vec2f>>
-    {
-    protected:
-        void SetUp() override
-        {
-            vector = std::get<0>(GetParam());
-            scalar = std::get<1>(GetParam());
-            expected = std::get<2>(GetParam());
-        }
-        Vec2f vector, expected;
-        float scalar;
-    };
-
-    class VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, Vec2f>>
-    {
-    protected:
-        void SetUp() override
-        {
-            vectorOne = std::get<0>(GetParam());
-            vectorTwo = std::get<1>(GetParam());
-            expected = std::get<2>(GetParam());
-        }
-        Vec2f vectorOne, vectorTwo, expected;
-    };
-
-    // Vec2f operator + (const Vec2f& vector) const
-    class AddVectorF : public VecVecVecFixture {};
-    TEST_P(AddVectorF, AddVector)
-    {
-        Vec2f output = vectorOne + vectorTwo;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);
-    }
-
-    INSTANTIATE_TEST_SUITE_P(AddVector, AddVectorF, testing::Values(
-        std::make_tuple(Vec2f(1.1f, 2.2f), Vec2f(3.3f, 4.4f), Vec2f(4.4f, 6.6f)),
-        std::make_tuple(Vec2f(-2.5f, 5.1f), Vec2f(7.2f, -3.3f), Vec2f(4.7f, 1.8f)),
-        std::make_tuple(Vec2f(0.0f, -8.4f), Vec2f(-4.4f, 6.6f), Vec2f(-4.4f, -1.8f)),
-        std::make_tuple(Vec2f(10.0f, -10.0f), Vec2f(-10.0f, 10.0f), Vec2f(0.0f, 0.0f))
-    ));
-
-    // void operator += (const Vec2f& vector)
-    class AddEqualsVectorF : public VecVecVecFixture {};
-    TEST_P(AddEqualsVectorF, AddEqualsVector)
-    {
-        vectorOne += vectorTwo;
-        ASSERT_EQ(expected.x, vectorOne.x);
-        ASSERT_EQ(expected.y, vectorOne.y);
-    }
-
-    INSTANTIATE_TEST_SUITE_P(AddEqualsVector, AddEqualsVectorF, testing::Values(
-        std::make_tuple(Vec2f(1.1f, 2.2f), Vec2f(3.3f, 4.4f), Vec2f(4.4f, 6.6f)),
-        std::make_tuple(Vec2f(-2.5f, 5.1f), Vec2f(7.2f, -3.3f), Vec2f(4.7f, 1.8f)),
-        std::make_tuple(Vec2f(0.0f, -8.4f), Vec2f(-4.4f, 6.6f), Vec2f(-4.4f, -1.8f)),
-        std::make_tuple(Vec2f(10.0f, -10.0f), Vec2f(-10.0f, 10.0f), Vec2f(0.0f, 0.0f))
-    ));
-
-    // Vec2f operator - (const Vec2f& vector) const
-    class SubtractVectorF : public VecVecVecFixture {};
-    TEST_P(SubtractVectorF, SubtractVector)
-    {
-        Vec2f output = vectorOne - vectorTwo;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);
-    }
-
-    INSTANTIATE_TEST_SUITE_P(SubtractVector, SubtractVectorF, testing::Values(
-        std::make_tuple(Vec2f(5.5f, 7.7f), Vec2f(3.3f, 2.2f), Vec2f(2.2f, 5.5f)),
-        std::make_tuple(Vec2f(10.0f, 10.0f), Vec2f(4.5f, 6.5f), Vec2f(5.5f, 3.5f)),
-        std::make_tuple(Vec2f(-3.3f, 8.8f), Vec2f(2.2f, -5.5f), Vec2f(-5.5f, 14.3f)),
-        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(-7.7f, 9.9f), Vec2f(7.7f, -9.9f))
-    ));
-
-    // void operator -= (const Vec2f& vector)
-    class SubtractEqualsVectorF : public VecVecVecFixture {};
-    TEST_P(SubtractEqualsVectorF, SubtractEqualsVector)
-    {
-        vectorOne -= vectorTwo;
-        ASSERT_EQ(expected.x, vectorOne.x);
-        ASSERT_EQ(expected.y, vectorOne.y);
-    }
-
-    INSTANTIATE_TEST_SUITE_P(SubtractEqualsVector, SubtractEqualsVectorF, testing::Values(
-        std::make_tuple(Vec2f(5.5f, 7.7f), Vec2f(3.3f, 2.2f), Vec2f(2.2f, 5.5f)),
-        std::make_tuple(Vec2f(10.0f, 10.0f), Vec2f(4.5f, 6.5f), Vec2f(5.5f, 3.5f)),
-        std::make_tuple(Vec2f(-3.3f, 8.8f), Vec2f(2.2f, -5.5f), Vec2f(-5.5f, 14.3f)),
-        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(-7.7f, 9.9f), Vec2f(7.7f, -9.9f))
-    ));
-
-    // Vec2f operator * (float scalar) const
-    class MultiplyByScalarF : public VecScaVecFixture {};
-    TEST_P(MultiplyByScalarF, MultiplyByScalar)
-    {
-        Vec2f output = vector * scalar;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);   
-    }
-
-    INSTANTIATE_TEST_SUITE_P(MultiplyByScalar, MultiplyByScalarF, testing::Values(
-        std::make_tuple(Vec2f(0.0f, 0.0f), 10.0f, Vec2f(0.0f, 0.0f)),
-        std::make_tuple(Vec2f(3.3f, 4.4f), 10.0f, Vec2f(33.0f, 44.0f)),
-        std::make_tuple(Vec2f(-6.6f, 4.4f), 5.0f, Vec2f(-33.0f, 22.0f)),
-        std::make_tuple(Vec2f(8.8f, -7.7f), -5.0f, Vec2f(-44.0f, 38.5f))
-    ));
-
-    // Vec2f operator * (const Vec2f& vector) const
-    class MultiplyByVectorF : public VecVecVecFixture {};
-    TEST_P(MultiplyByVectorF, MultiplyByVector)
-    {
-        Vec2f output = vectorOne * vectorTwo;
-        ASSERT_EQ(expected.x, output.x);
-        ASSERT_EQ(expected.y, output.y);   
-    }
-
-    INSTANTIATE_TEST_SUITE_P(MultiplyByVector, MultiplyByVectorF, testing::Values(
-        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(10.0f, 10.0f), Vec2f(0.0f, 0.0f)),
-        std::make_tuple(Vec2f(3.3f, 4.4f), Vec2f(5.5f, 10.0f), Vec2f(18.15f, 44.0f)),
-        std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(5.5f, -5.0f), Vec2f(-36.3f, -22.0f)),
-        std::make_tuple(Vec2f(8.8f, -7.7f), Vec2f(-5.5f, -5.5f), Vec2f(-48.4f, 42.35f))
-    ));
-
-    // void operator *= (float scalar)
-    class MultiplyEqualsByScalarF : public VecScaVecFixture {};
-    TEST_P(MultiplyEqualsByScalarF, MultiplyEqualsByScalar)
-    {
-        vector *= scalar;
-        ASSERT_EQ(expected.x, vector.x);
-        ASSERT_EQ(expected.y, vector.y);   
-    }
-
-    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByScalar, MultiplyEqualsByScalarF, testing::Values(
-        std::make_tuple(Vec2f(0.0f, 0.0f), 10.0f, Vec2f(0.0f, 0.0f)),
-        std::make_tuple(Vec2f(3.3f, 4.4f), 10.0f, Vec2f(33.0f, 44.0f)),
-        std::make_tuple(Vec2f(-6.6f, 4.4f), 5.0f, Vec2f(-33.0f, 22.0f)),
-        std::make_tuple(Vec2f(8.8f, -7.7f), -5.0f, Vec2f(-44.0f, 38.5f))
-    ));
-
-    // void operator *= (const Vec2f& vector)
-    class MultiplyEqualsByVectorF : public VecVecVecFixture {};
-    TEST_P(MultiplyEqualsByVectorF, MultiplyEqualsByVector)
-    {
-        vectorOne *= vectorTwo;
-        ASSERT_EQ(expected.x, vectorOne.x);
-        ASSERT_EQ(expected.y, vectorOne.y);   
-    }
-
-    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByVector, MultiplyEqualsByVectorF, testing::Values(
-        std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(10.0f, 10.0f), Vec2f(0.0f, 0.0f)),
-        std::make_tuple(Vec2f(3.3f, 4.4f), Vec2f(5.5f, 10.0f), Vec2f(18.15f, 44.0f)),
-        std::make_tuple(Vec2f(-6.6f, 4.4f), Vec2f(5.5f, -5.0f), Vec2f(-36.3f, -22.0f)),
-        std::make_tuple(Vec2f(8.8f, -7.7f), Vec2f(-5.5f, -5.5f), Vec2f(-48.4f, 42.35f))
-    ));
-
-    class VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2f, Vec2f, bool>>
-    {
-    protected:
-        void SetUp() override
-        {
-            vectorOne = std::get<0>(GetParam());
-            vectorTwo = std::get<1>(GetParam());
-            expected = std::get<2>(GetParam());
-        }
-        Vec2f vectorOne, vectorTwo;
-        bool expected;
-    };
-
-    // bool operator == (const Vec2f& vector) const
-    class CompareVectorsF : public VecVecBoolFixture {};
-    TEST_P(CompareVectorsF, CompareVectors)
-    {
-        bool output = vectorOne == vectorTwo;
-        ASSERT_EQ(expected, output);
-        ASSERT_EQ(expected, output);   
-    }
-
-    INSTANTIATE_TEST_SUITE_P(CompareVectors, CompareVectorsF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2f_CompareVectors, Vec2f_CompareVectorsF, testing::Values(
         std::make_tuple(Vec2f(-5.5f, 5.5f), Vec2f(-5.5f, 5.5f), true),
         std::make_tuple(Vec2f(0.0f, 0.0f), Vec2f(0.0f, 0.0f), true),
         std::make_tuple(Vec2f(-5.5f, 5.5f), Vec2f(5.5f, -5.5f), false),

--- a/test/Vec2f_Test.cpp
+++ b/test/Vec2f_Test.cpp
@@ -357,6 +357,21 @@ namespace Vec2d_Tests
         std::make_tuple(Vec2f(-5.f, 0.f), Vec2f(-10.2f, 4.f), 51.f)
     ));
 
+    // Vec2f Vec2f::normalise() const
+    class Vec2f_NormaliseF : public Vec2f_VecVecVecFixture {};
+    TEST_P(Vec2f_NormaliseF, Vec2f_Normalise)
+    {
+        Vec2f output = vectorOne.normalise();
+        ASSERT_NEAR(expected.x, output.x, 1E-05);
+        ASSERT_NEAR(expected.y, output.y, 1E-05);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec2f_Normalise, Vec2f_NormaliseF, testing::Values(
+        std::make_tuple(Vec2f(5.f, 5.f), Vec2f(0.f, 0.f), Vec2f(0.707107f, 0.707107f)),
+        std::make_tuple(Vec2f(-5.f, -5.f), Vec2f(0.f, 0.f), Vec2f(-0.707107f, -0.707107f)),
+        std::make_tuple(Vec2f(-6.f, 8.f), Vec2f(0.f, 0.f), Vec2f(-0.6f, 0.8f))
+    ));
+
     class Vec2f_VecFloatFloatFixture : public testing::TestWithParam<std::tuple<Vec2f, float, float>>
     {
         protected:

--- a/test/Vec2i_Test.cpp
+++ b/test/Vec2i_Test.cpp
@@ -4,23 +4,23 @@
 
 using namespace vecp;
 
-namespace Vec2Int_Tests
+namespace Vec2i_Tests
 {
-    TEST(TestConstructorDefault, SetDefaultValues)
+    TEST(Vec2i_TestConstructorDefault, SetDefaultValues)
     {   
         Vec2i vector = Vec2i();
         ASSERT_EQ(vector.x, 0);
         ASSERT_EQ(vector.y, 0);
     }
 
-    TEST(TestConstructorValues, SetSpecifiedValues)
+    TEST(Vec2i_TestConstructorValues, SetSpecifiedValues)
     {
         Vec2i vector = Vec2i(-3, 4);
         ASSERT_EQ(vector.x, -3);
         ASSERT_EQ(vector.y, 4);
     }
 
-    class VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2i, int, Vec2i>>
+    class Vec2i_VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec2i, int, Vec2i>>
     {
         protected:
             void SetUp() override
@@ -33,7 +33,7 @@ namespace Vec2Int_Tests
             int scalar;
     };
 
-    class VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2i, Vec2i, Vec2i>>
+    class Vec2i_VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec2i, Vec2i, Vec2i>>
     {
         protected:
             void SetUp() override
@@ -46,15 +46,15 @@ namespace Vec2Int_Tests
     };
 
     // Vec2i operator + (const Vec2i& vector) const
-    class AddVectorF : public VecVecVecFixture {};
-    TEST_P(AddVectorF, AddVector)
+    class Vec2i_AddVectorF : public Vec2i_VecVecVecFixture {};
+    TEST_P(Vec2i_AddVectorF, Vec2i_AddVector)
     {
         Vec2i output = vectorOne + vectorTwo;
         ASSERT_EQ(expected.x, output.x);
         ASSERT_EQ(expected.y, output.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(AddVector, AddVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_AddVector, Vec2i_AddVectorF, testing::Values(
         std::make_tuple(Vec2i(1, 2), Vec2i(3, 4), Vec2i(4, 6)),
         std::make_tuple(Vec2i(-2, 5), Vec2i(7, -3), Vec2i(5, 2)),
         std::make_tuple(Vec2i(0, -8), Vec2i(-4, 6), Vec2i(-4, -2)),
@@ -63,15 +63,15 @@ namespace Vec2Int_Tests
 
 
     // void operator += (const Vec2i& vector)
-    class AddEqualsVectorF : public VecVecVecFixture {};
-    TEST_P(AddEqualsVectorF, AddEqualsVector)
+    class Vec2i_AddEqualsVectorF : public Vec2i_VecVecVecFixture {};
+    TEST_P(Vec2i_AddEqualsVectorF, Vec2i_AddEqualsVector)
     {
         vectorOne += vectorTwo;
         ASSERT_EQ(expected.x, vectorOne.x);
         ASSERT_EQ(expected.y, vectorOne.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(AddEqualsVector, AddEqualsVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_AddEqualsVector, Vec2i_AddEqualsVectorF, testing::Values(
         std::make_tuple(Vec2i(1, 2), Vec2i(3, 4), Vec2i(4, 6)),
         std::make_tuple(Vec2i(-2, 5), Vec2i(7, -3), Vec2i(5, 2)),
         std::make_tuple(Vec2i(0, -8), Vec2i(-4, 6), Vec2i(-4, -2)),
@@ -79,15 +79,15 @@ namespace Vec2Int_Tests
     ));
 
     // Vec2i operator - (const Vec2i& vector) const
-    class SubtractVectorF : public VecVecVecFixture {};
-    TEST_P(SubtractVectorF, SubtractVector)
+    class Vec2i_SubtractVectorF : public Vec2i_VecVecVecFixture {};
+    TEST_P(Vec2i_SubtractVectorF, Vec2i_SubtractVector)
     {
         Vec2i output = vectorOne - vectorTwo;
         ASSERT_EQ(expected.x, output.x);
         ASSERT_EQ(expected.y, output.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(SubtractVector, SubtractVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_SubtractVector, Vec2i_SubtractVectorF, testing::Values(
         std::make_tuple(Vec2i(5, 7), Vec2i(3, 2), Vec2i(2, 5)),
         std::make_tuple(Vec2i(10, 10), Vec2i(4, 6), Vec2i(6, 4)),
         std::make_tuple(Vec2i(-3, 8), Vec2i(2, -5), Vec2i(-5, 13)),
@@ -95,15 +95,15 @@ namespace Vec2Int_Tests
     ));
 
     // void operator -= (const Vec2i& vector)
-    class SubtractEqualsVectorF : public VecVecVecFixture {};
-    TEST_P(SubtractEqualsVectorF, SubtractEqualsVector)
+    class Vec2i_SubtractEqualsVectorF : public Vec2i_VecVecVecFixture {};
+    TEST_P(Vec2i_SubtractEqualsVectorF, Vec2i_SubtractEqualsVector)
     {
         vectorOne -= vectorTwo;
         ASSERT_EQ(expected.x, vectorOne.x);
         ASSERT_EQ(expected.y, vectorOne.y);
     }
 
-    INSTANTIATE_TEST_SUITE_P(SubtractEqualsVector, SubtractEqualsVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_SubtractEqualsVector, Vec2i_SubtractEqualsVectorF, testing::Values(
         std::make_tuple(Vec2i(5, 7), Vec2i(3, 2), Vec2i(2, 5)),
         std::make_tuple(Vec2i(10, 10), Vec2i(4, 6), Vec2i(6, 4)),
         std::make_tuple(Vec2i(-3, 8), Vec2i(2, -5), Vec2i(-5, 13)),
@@ -111,15 +111,15 @@ namespace Vec2Int_Tests
     ));
 
     // Vec2i operator * (int scalar) const
-    class MultiplyByScalarF : public VecScaVecFixture {};
-    TEST_P(MultiplyByScalarF, MultiplyByScalar)
+    class Vec2i_MultiplyByScalarF : public Vec2i_VecScaVecFixture {};
+    TEST_P(Vec2i_MultiplyByScalarF, Vec2i_MultiplyByScalar)
     {
         Vec2i output = vector * scalar;
         ASSERT_EQ(expected.x, output.x);
         ASSERT_EQ(expected.y, output.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyByScalar, MultiplyByScalarF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_MultiplyByScalar, Vec2i_MultiplyByScalarF, testing::Values(
         std::make_tuple(Vec2i(0, 0), 10, Vec2i(0, 0)),
         std::make_tuple(Vec2i(3, 4), 10, Vec2i(30, 40)),
         std::make_tuple(Vec2i(-6, 4), 5, Vec2i(-30, 20)),
@@ -127,15 +127,15 @@ namespace Vec2Int_Tests
     ));
 
     // Vec2i operator * (const Vec2i& vector) const
-    class MultiplyByVectorF : public VecVecVecFixture {};
-    TEST_P(MultiplyByVectorF, MultiplyByVector)
+    class Vec2i_MultiplyByVectorF : public Vec2i_VecVecVecFixture {};
+    TEST_P(Vec2i_MultiplyByVectorF, Vec2i_MultiplyByVector)
     {
         Vec2i output = vectorOne * vectorTwo;
         ASSERT_EQ(expected.x, output.x);
         ASSERT_EQ(expected.y, output.y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(MultiplyByVector, MultiplyByVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_MultiplyByVector, Vec2i_MultiplyByVectorF, testing::Values(
         std::make_tuple(Vec2i(0, 0), Vec2i(10, 10), Vec2i(0, 0)),
         std::make_tuple(Vec2i(3, 4), Vec2i(5, 10), Vec2i(15, 40)),
         std::make_tuple(Vec2i(-6, 4), Vec2i(5, -5), Vec2i(-30, -20)),
@@ -143,15 +143,15 @@ namespace Vec2Int_Tests
     ));
 
     // void operator *= (int scalar)
-    class MultiplyEqualsByScalarF : public VecScaVecFixture {};
-    TEST_P(MultiplyEqualsByScalarF, MultiplyEqualsByScalar)
+    class Vec2i_MultiplyEqualsByScalarF : public Vec2i_VecScaVecFixture {};
+    TEST_P(Vec2i_MultiplyEqualsByScalarF, Vec2i_MultiplyEqualsByScalar)
     {
         vector *= scalar;
         ASSERT_EQ(expected.x, vector.x);
         ASSERT_EQ(expected.y, vector.y);   
     }
     
-    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByScalar, MultiplyEqualsByScalarF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_MultiplyEqualsByScalar, Vec2i_MultiplyEqualsByScalarF, testing::Values(
         std::make_tuple(Vec2i(0, 0), 10, Vec2i(0, 0)),
         std::make_tuple(Vec2i(3, 4), 10, Vec2i(30, 40)),
         std::make_tuple(Vec2i(-6, 4), 5, Vec2i(-30, 20)),
@@ -159,22 +159,22 @@ namespace Vec2Int_Tests
     ));
 
     // void operator *= (const Vec2i& vector)
-    class MultiplyEqualsByVectorF : public VecVecVecFixture {};
-    TEST_P(MultiplyEqualsByVectorF, MultiplyEqualsByVector)
+    class Vec2i_MultiplyEqualsByVectorF : public Vec2i_VecVecVecFixture {};
+    TEST_P(Vec2i_MultiplyEqualsByVectorF, Vec2i_MultiplyEqualsByVector)
     {
         vectorOne *= vectorTwo;
         ASSERT_EQ(expected.x, vectorOne.x);
         ASSERT_EQ(expected.y, vectorOne.y);   
     }
     
-    INSTANTIATE_TEST_SUITE_P(MultiplyEqualsByVector, MultiplyEqualsByVectorF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_MultiplyEqualsByVector, Vec2i_MultiplyEqualsByVectorF, testing::Values(
         std::make_tuple(Vec2i(0, 0), Vec2i(10, 10), Vec2i(0, 0)),
         std::make_tuple(Vec2i(3, 4), Vec2i(5, 10), Vec2i(15, 40)),
         std::make_tuple(Vec2i(-6, 4), Vec2i(5, -5), Vec2i(-30, -20)),
         std::make_tuple(Vec2i(8, -7), Vec2i(-5, -5), Vec2i(-40, 35))
     ));
 
-    class VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2i, Vec2i, bool>>
+    class Vec2i_VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec2i, Vec2i, bool>>
     {
         protected:
             void SetUp() override
@@ -188,15 +188,15 @@ namespace Vec2Int_Tests
     };
 
     // bool operator == (const Vec2i& vector) const
-    class CompareVectorsF : public VecVecBoolFixture {};
-    TEST_P(CompareVectorsF, CompareVectors)
+    class Vec2i_CompareVectorsF : public Vec2i_VecVecBoolFixture {};
+    TEST_P(Vec2i_CompareVectorsF, Vec2i_CompareVectors)
     {
         bool output = vectorOne == vectorTwo;
         ASSERT_EQ(expected, output);
         ASSERT_EQ(expected, output);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(CompareVectors, CompareVectorsF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_CompareVectors, Vec2i_CompareVectorsF, testing::Values(
         std::make_tuple(Vec2i(-5, 5), Vec2i(-5, 5), true),
         std::make_tuple(Vec2i(0, 0), Vec2i(0, 0), true),
         std::make_tuple(Vec2i(-5, 5), Vec2i(5, -5), false),
@@ -204,7 +204,7 @@ namespace Vec2Int_Tests
     ));
 
 
-    class VecFloatFloatFixture : public testing::TestWithParam<std::tuple<Vec2i, float, float>>
+    class Vec2i_VecFloatFloatFixture : public testing::TestWithParam<std::tuple<Vec2i, float, float>>
     {
         protected:
             void SetUp() override
@@ -218,8 +218,8 @@ namespace Vec2Int_Tests
     };
 
     // Vec2f toFloat() const
-    class ConvertToFloatF : public VecFloatFloatFixture {};
-    TEST_P(ConvertToFloatF, ConvertToFloat)
+    class Vec2i_ConvertToFloatF : public Vec2i_VecFloatFloatFixture {};
+    TEST_P(Vec2i_ConvertToFloatF, Vec2i_ConvertToFloat)
     { 
         ASSERT_EQ(typeid(float), typeid(vector.toFloat().x));
         ASSERT_EQ(typeid(float), typeid(vector.toFloat().y));   
@@ -227,7 +227,7 @@ namespace Vec2Int_Tests
         ASSERT_EQ(expectedY, vector.toFloat().y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(ConvertToFloat, ConvertToFloatF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_ConvertToFloat, Vec2i_ConvertToFloatF, testing::Values(
         std::make_tuple(Vec2i(0, 0), 0.f, 0.f),
         std::make_tuple(Vec2i(5, 5), 5.f, 5.f),
         std::make_tuple(Vec2i(-5, -5), -5.f, -5.f),
@@ -235,8 +235,8 @@ namespace Vec2Int_Tests
     ));
 
     // Vec2d toDouble() const
-    class ConvertToDoubleF : public VecFloatFloatFixture {};
-    TEST_P(ConvertToDoubleF, ConvertToDouble)
+    class Vec2i_ConvertToDoubleF : public Vec2i_VecFloatFloatFixture {};
+    TEST_P(Vec2i_ConvertToDoubleF, Vec2i_ConvertToDouble)
     { 
         double expectX = (double)expectedX;
         double expectY = (double)expectedY;
@@ -246,7 +246,7 @@ namespace Vec2Int_Tests
         ASSERT_EQ(expectY, vector.toDouble().y);   
     }
 
-    INSTANTIATE_TEST_SUITE_P(ConvertToDouble, ConvertToDoubleF, testing::Values(
+    INSTANTIATE_TEST_SUITE_P(Vec2i_ConvertToDouble, Vec2i_ConvertToDoubleF, testing::Values(
         std::make_tuple(Vec2i(0, 0), 0., 0.),
         std::make_tuple(Vec2i(5, 5), 5., 5.),
         std::make_tuple(Vec2i(-5, -5), -5., -5.),


### PR DESCRIPTION
Completed all tests for the Vec2Decimal<float> (Vec2f) and Vec2Decimal<double> (Vec2d) instantiations of the Vec2Decimal template class.

This template class extends the Vec2Base template class with additional functionality for operations which are specific to vectors of decimal type numeric primitives.

- Calculation of magnitude.
- Calculation of distance between two vectors.
- Division of vector components by a second set of corresponding vector components.
- Normalisation of vector.