### PR TITLE
Vec3d

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ target_sources(${PROJECT_NAME}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}/Vec2Decimal.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}/Vec2Int.cpp 
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}/Vec3Decimal.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}/Vec3Int.cpp 
 )
 
 target_include_directories(${PROJECT_NAME}
@@ -53,7 +55,14 @@ else()
     )
 endif()
 
-set(public_headers include/VecPlus/Vec2.h include/VecPlus/Vec2Decimal.h include/VecPlus/Vec2Int.h)
+set(public_headers 
+    include/VecPlus/Vec2.h 
+    include/VecPlus/Vec2Decimal.h 
+    include/VecPlus/Vec2Int.h
+    include/VecPlus/Vec3.h
+    include/VecPlus/Vec3Int.h
+    include/VecPlus/vec3Decimal.h
+    )
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${public_headers}")
 
 #install(DIRECTORY include/ DESTINATION include)

--- a/include/VecPlus/Vec3.h
+++ b/include/VecPlus/Vec3.h
@@ -1,0 +1,13 @@
+#pragma once
+
+//#include <VecPlus/Vec3Decimal.h>
+#include <VecPlus/Vec3Int.h>
+
+namespace vecp
+{
+    using Vec3i = Vec3Int<int>;
+
+    using Vec3f = Vec3Decimal<float>;
+
+    using Vec3d = Vec3Decimal<double>;
+}

--- a/include/VecPlus/Vec3Base.h
+++ b/include/VecPlus/Vec3Base.h
@@ -1,0 +1,102 @@
+#pragma once
+#include <cmath>
+
+namespace vecp
+{
+    /*!
+     * \brief Represents a 3D vector with components of type T.
+     * 
+     * This template class provides basic operations for generic 3D vectors 
+     * such as addition, subtraction, multiplication, and boolean comparision.
+     * 
+     * \tparam T The type of elements in the vector (e.g. float, double, int).
+     * 
+    */
+    template <typename T, template <typename> class Derived>
+    class Vec3Base
+    {
+    public:
+        T x; /// The x-coordinate of the vector.
+        T y; /// The y-coordinate of the vector.
+        T z; /// The z-coordiante of the vector
+        
+        /*!
+         * \brief Overload the addition operator (+) for vector addition.
+         * 
+         * \param vector The vector to be added to  the current vector.
+         * \return A new vector containing the modified values.
+         * 
+        */
+        Derived<T> operator + (const Derived<T>& vector) const;
+
+        /*!
+         * \brief Overload the addition assignment operator (+=) for vector addition.
+         * 
+         * \param vector The vector to be added to the current vector.
+        */
+        void operator += (const Derived<T> vector);
+        
+        /*!
+         * \brief Overload the subtration operator (-) for vector subtraction.
+         * 
+         * \param vector The vector to be subtracted from the current vector.
+         * \return A new vector containing the modified values.
+         * 
+        */
+        Derived<T> operator - (const Derived<T>& vector) const;
+
+        /*!
+         * \brief Overload the subtraction assignment operator (-=) for vector subtraction.
+         * 
+         * \param vector The vector to be subtracted from the current vector.
+        */
+        void operator -= (const Derived<T>& vector);
+
+        /*!
+         * \brief Overload the multiplication operator (*) for vector by scalar multiplication.
+         * 
+         * \param value The scalar value to be multiplied.
+         * \return A new vector containing the modified values.
+        */
+        Derived<T> operator * (T value) const;
+        
+        /*!
+         * \brief Overload the multiplication operator (*) for vector by vector multiplication.
+         * 
+         * \param vector The vector to multiple the current vector values by.
+         * \return A new vector containing the modified values.
+        */
+        Derived<T> operator * (const Derived<T>& vector) const;
+        
+        /*!
+         * \brief Overload the multiplication operator (*=) for vector by scalar multiplication.
+         * 
+         * \param value The scalar value to multiply the current vector by.
+        */
+        void operator *= (T value);
+
+        /*!
+         * \brief Overload the multiplication operator (*=) for vector by vector multiplication.
+         * 
+         * \param vector The vector multiply the current vector values by.
+        */
+        void operator *= (const Derived<T>& vector);
+
+        /*!
+         * \brief Overload the equality operator (==) for vector comparison.
+         *
+         * \param vector The vector to compare with.
+         * \return True if both vector components are equal, otherwise false.
+        */
+
+        bool operator == (const Derived<T>& vector);
+
+        /*!
+         * \brief Construct a new Vec2 object with given x and y components.
+         * 
+         * \param xin The x component of the vector.
+         * \param yin The y component of the vector.
+        */
+        Vec3Base(T xin = T(), T yin = T(), T zin = T()) : x(xin), y(yin), z(zin) {}
+    };
+}

--- a/include/VecPlus/Vec3Decimal.h
+++ b/include/VecPlus/Vec3Decimal.h
@@ -1,11 +1,11 @@
 #pragma once
-#include <VecPlus/Vec2Base.h>
+#include <VecPlus/Vec3Base.h>
 
 namespace vecp
 {
 
     /*! 
-     * \brief Represents a 2D vector with components of primative decimal types.
+     * \brief Represents a 3D vector with components of primative decimal types.
      * 
      * Extends the Vec2Base class with functionality for division, rotation, 
      * calculation of mangitude, and calculation of the dot product.
@@ -14,7 +14,7 @@ namespace vecp
      * 
     */
     template <typename T>
-    class Vec2Decimal : public Vec2Base<T, Vec2Decimal>
+    class Vec3Decimal : public Vec3Base<T, Vec3Decimal>
     {
     public:
         
@@ -33,14 +33,14 @@ namespace vecp
          * \return The magnitude of the transform vector.
          * 
         */
-        T mag(const Vec2Decimal<T>& vector) const;
+        T mag(const Vec3Decimal<T>& vector) const;
 
         /*!
          * \brief Apply a rotation to the vector by a given angle.
          * 
          * \param angle The angle (in degrees) by which to rotate the vector.
         */
-        Vec2Decimal<T> rotate(T angle) const;
+        Vec3Decimal<T> rotate(char axis, T angle) const;
 
 
         /*!
@@ -49,7 +49,7 @@ namespace vecp
          * \param value The scalar value to divide the current vector by.
          * \return A new vector containing the modified values.
         */
-        Vec2Decimal<T> operator / (T value) const;
+        Vec3Decimal<T> operator / (T value) const;
 
         /*!
          * \brief Overload the division operator (/) for vector by vector division.
@@ -57,7 +57,7 @@ namespace vecp
          * \param vector The vector to divide the current vector values by.
          * \return A new vector containing the modified values.
         */
-        Vec2Decimal<T> operator / (const Vec2Decimal<T>& vector) const;
+        Vec3Decimal<T> operator / (const Vec3Decimal<T>& vector) const;
         
         /*!
          * \brief Overload the division operator (/=) for vector by scalar division.
@@ -71,7 +71,7 @@ namespace vecp
          * 
          * \param vector The vector to divide the current vector values by.
         */
-        void operator /= (const Vec2Decimal<T>& vector);
+        void operator /= (const Vec3Decimal<T>& vector);
 
         /*!
          * \brief Calculate dot product of the current vector and another vector.
@@ -79,10 +79,10 @@ namespace vecp
          * \param vector The vector to apply to the current vector.
          * \return The dot product of the vectors.
         */
-        T dot(const Vec2Decimal<T>& vector) const;
+        T dot(const Vec3Decimal<T>& vector) const;
 
         /*!
-         * \brief Calculate dot product of the current vector a vector of two identical scalar values.
+         * \brief Calculate dot product of the current vector a vector of three identical scalar values.
          * 
          * \param value The x & y scalar value to apply to the current vector.
          * \return The dot product of the vectors.
@@ -90,48 +90,49 @@ namespace vecp
         T dot(T value) const;
 
         /*!
-         * \brief Calculate dot product of the current vector and a vector of two scalar values.
+         * \brief Calculate dot product of the current vector and a vector of three scalar values.
          * 
          * \param xTwo The x scalar value to apply to the current vector.
          * \param yTwo The y scalar valeu to apply to the current vector.
+         * \param zTwo The z scalar valeu to apply to the current vector.
          * \return The dot product of the vectors.
         */
-        T dot(T xTwo, T yTwo) const;
+        T dot(T xTwo, T yTwo, T zTwo) const;
 
         /*!
          * \brief Normalise the current vector and return the result as a new vector.
          *
          * \return A new vector containing the normalised x and y components.
         */
-        Vec2Decimal<T> normalise() const;
+        Vec3Decimal<T> normalise() const;
 
         /**
-         * \brief Convert current vector to a Vec2f instance.
+         * \brief Convert current vector to a Vec3f instance.
          * 
          * \return A new vector containing the equivalent float values.
          */
-        Vec2Decimal<float> toFloat() const;
+        Vec3Decimal<float> toFloat() const;
         
         /**
-         * \brief Convert current vector to a Vec2d instance.
+         * \brief Convert current vector to a Vec3d instance.
          * 
          * \return A new vector containing the equivalent double values.
          */
-        Vec2Decimal<double> toDouble() const;
+        Vec3Decimal<double> toDouble() const;
 
-        using Vec2Base<T, Vec2Decimal>::Vec2Base;
+        using Vec3Base<T, Vec3Decimal>::Vec3Base;
         //Vec2fd(T xin = 0., T yin = 0.);
 
     private:
         double m_pi = 3.141592653589793;
     }; 
 
-    extern template class Vec2Decimal<float>;
+    extern template class Vec3Decimal<float>;
 
-    extern template class Vec2Decimal<double>;
+    extern template class Vec3Decimal<double>;
 
-    extern template class Vec2Base<float, Vec2Decimal>;
+    extern template class Vec3Base<float, Vec3Decimal>;
 
-    extern template class Vec2Base<double, Vec2Decimal>;
+    extern template class Vec3Base<double, Vec3Decimal>;
 
 }

--- a/include/VecPlus/Vec3Int.h
+++ b/include/VecPlus/Vec3Int.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "Vec3Base.h"
+#include <VecPlus/Vec3Decimal.h>
+
+namespace vecp
+{
+    /*!
+     * \brief Represents a 2D vector with components of privative integer types.
+     * 
+     * Extends the Vec2Base class with functionaltiy for converting the vector 
+     * into a Vec2Decimal types of either floats or doubles.
+     * 
+     * \tparam T The type of elements in the vector (e.g. float, double, int).
+     * 
+    */
+    template<typename T>
+    class Vec3Int : public Vec3Base<T, Vec3Int>
+    {
+    public:
+        /**
+         * \brief Convert current vector to a Vec2f instance.
+         * 
+         * \return A new vector containing the equivalent float values.
+         */
+        Vec3Decimal<float> toFloat() const;
+        
+        /**
+         * \brief Convert current vector to a Vec2d instance.
+         * 
+         * \return A new vector containing the equivalent double values.
+         */
+        Vec3Decimal<double> toDouble() const;
+
+        using Vec3Base<T, Vec3Int>::Vec3Base;
+        //Vec2int(int xin = 0, int yin = 0);
+    };
+
+    extern template class Vec3Base<int, Vec3Int>;
+
+    extern template class Vec3Int<int>;
+}

--- a/src/VecPlus/Vec3Base.inl
+++ b/src/VecPlus/Vec3Base.inl
@@ -1,0 +1,67 @@
+#pragma once
+
+namespace vecp
+{
+
+    template <typename T, template <typename> class Derived>
+    Derived<T> Vec3Base<T, Derived>::operator + (const Derived<T>& vector) const
+    {
+        return Derived<T>(this->x + vector.x, this->y + vector.y, this->z + vector.z);
+    }
+
+    template <typename T, template <typename> class Derived>
+    void Vec3Base<T, Derived>::operator += (const Derived<T> vector)
+    {
+        this->x += vector.x;
+        this->y += vector.y;
+        this->z += vector.z;
+    }
+
+    template <typename T, template <typename> class Derived>
+    Derived<T> Vec3Base<T, Derived>::operator - (const Derived<T>& vector) const
+    {
+        return Derived<T>(this->x - vector.x, this->y - vector.y, this->z - vector.z);
+    }
+
+    template <typename T, template <typename> class Derived>
+    void Vec3Base<T, Derived>::operator -= (const Derived<T>& vector)
+    {
+        this->x -= vector.x;
+        this->y -= vector.y;
+        this->z -= vector.z;
+    }
+
+    template <typename T, template <typename> class Derived>
+    Derived<T> Vec3Base<T, Derived>::operator * (T value) const
+    {
+        return Derived<T>(this->x * value, this->y * value, this->z * value);
+    }
+    
+    template <typename T, template <typename> class Derived>
+    Derived<T> Vec3Base<T, Derived>::operator * (const Derived<T>& vector) const
+    {
+        return Derived<T>(this->x * vector.x, this->y * vector.y, this->z * vector.z);
+    }
+    
+    template <typename T, template <typename> class Derived>
+    void Vec3Base<T, Derived>::operator *= (T value)
+    {
+        this->x *= value;
+        this->y *= value;
+        this->z *= value;
+    }
+
+    template <typename T, template <typename> class Derived>
+    void Vec3Base<T, Derived>::operator *= (const Derived<T>& vector)
+    {
+        this->x *= vector.x;
+        this->y *= vector.y;
+        this->z *= vector.z;
+    }
+
+    template <typename T, template <typename> class Derived>
+    bool Vec3Base<T, Derived>::operator == (const Derived<T>& vector)
+    {
+        return (this->x == vector.x && this->y == vector.y && this->z == vector.z);
+    }
+}

--- a/src/VecPlus/Vec3Decimal.cpp
+++ b/src/VecPlus/Vec3Decimal.cpp
@@ -1,0 +1,123 @@
+#include <VecPlus/Vec3Base.h>
+#include <VecPlus/Vec3Base.inl>
+#include <VecPlus/Vec3Decimal.h>
+
+
+namespace vecp
+{
+    template <typename T>
+    T Vec3Decimal<T>::mag() const
+    {
+        return sqrt(pow(this->x, 2) + pow(this->y, 2) + pow(this->y, 2));
+    }
+
+    template <typename T>
+    T Vec3Decimal<T>::mag(const Vec3Decimal<T>& vector) const
+    {
+        return sqrt(
+            pow(this->x - vector.x, 2) + 
+            pow(this->y - vector.y, 2) +
+            pow(this->z - vector.z, 2)
+        );
+    }
+
+    template <typename T>
+    Vec3Decimal<T> Vec3Decimal<T>::rotate(char axis, T angle) const
+    {
+        T cosAngle = cos(angle * this->m_pi / 180.);
+        T sinAngle = sin(angle * this->m_pi / 180.);
+        Vec3Decimal<T> vector = Vec3Decimal<T>(this->x, this->y, this->z);
+        switch (axis) {
+            case 'x':
+                vector.y = this->y * cosAngle - this->z * sinAngle;
+                vector.z = this->y * sinAngle + this->z * cosAngle;
+                break;
+            case 'y':
+                vector.z = this->z * cosAngle - this->x * sinAngle;
+                vector.x = this->z * sinAngle + this->x * cosAngle;
+                break;
+            case 'z':
+                vector.x = this->x * cosAngle - this->y * sinAngle;
+                vector.y = this->x * sinAngle + this->y * cosAngle;
+                break;
+        }
+        return vector;
+    }
+
+    template <typename T>
+    Vec3Decimal<T> Vec3Decimal<T>::operator / (T value) const
+    {
+        return Vec3Decimal<T>(this->x / value, this->y / value, this->z / value);
+    }
+
+    template <typename T>
+    Vec3Decimal<T> Vec3Decimal<T>::operator / (const Vec3Decimal<T>& vector) const
+    {
+        return Vec3Decimal<T>(this->x / vector.x, this->y / vector.y, this->z / vector.z);
+    }
+    
+    template <typename T>
+    void Vec3Decimal<T>::operator /= (T value)
+    {
+        this->x /= value;
+        this->y /= value;
+        this->z /= value;
+    }
+
+    template <typename T>
+    void Vec3Decimal<T>::operator /= (const Vec3Decimal<T>& vector)
+    {
+        this->x /= vector.x;
+        this->y /= vector.y;
+        this->z /= vector.z;
+    }
+
+    template <typename T>
+    T Vec3Decimal<T>::dot(const Vec3Decimal<T>& vector) const
+    {
+        return this->x * vector.x + this->y * vector.y + this->z * vector.z;
+    }
+
+    template <typename T>
+    T Vec3Decimal<T>::dot(T value) const
+    {
+        return this->x * value + this->y * value + this->z * value;
+    }
+
+    template <typename T>
+    T Vec3Decimal<T>::dot(T xTwo, T yTwo, T zTwo) const
+    {
+        return this->x * xTwo + this->y * yTwo + this->z * zTwo;
+    }
+
+    template <typename T>
+    Vec3Decimal<T> Vec3Decimal<T>::normalise() const
+    {
+        T magnitude = sqrt(pow(this->x, 2) + pow(this->y, 2) + pow(this->z, 2));
+        return Vec3Decimal<T>(this->x / magnitude, this->y / magnitude, this->z / magnitude);
+    }
+
+
+    template<typename T>
+    Vec3Decimal<float> Vec3Decimal<T>::toFloat() const
+    {
+        return Vec3Decimal<float>((float)this->x, (float)this->y, (float)this->z);
+    }
+
+    template<typename T>
+    Vec3Decimal<double> Vec3Decimal<T>::toDouble() const
+    {
+        return Vec3Decimal<double>((double)this->x, (double)this->y, (double)this->z);
+    }
+
+    template class Vec3Base<float, Vec3Decimal>;
+
+    template class Vec3Base<double, Vec3Decimal>;
+
+    template class Vec3Decimal<float>;
+
+    template class Vec3Decimal<double>;
+
+
+
+}

--- a/src/VecPlus/Vec3Decimal.cpp
+++ b/src/VecPlus/Vec3Decimal.cpp
@@ -8,7 +8,7 @@ namespace vecp
     template <typename T>
     T Vec3Decimal<T>::mag() const
     {
-        return sqrt(pow(this->x, 2) + pow(this->y, 2) + pow(this->y, 2));
+        return sqrt(pow(this->x, 2) + pow(this->y, 2) + pow(this->z, 2));
     }
 
     template <typename T>

--- a/src/VecPlus/Vec3Int.cpp
+++ b/src/VecPlus/Vec3Int.cpp
@@ -1,0 +1,27 @@
+#include <VecPlus/Vec3Base.h>
+#include <VecPlus/Vec3Base.inl>
+#include <VecPlus/Vec3Int.h>
+
+namespace vecp
+{
+    template<typename T>
+    Vec3Decimal<float> Vec3Int<T>::toFloat() const
+    {
+        return Vec3Decimal<float>((float)this->x, (float)this->y, (float)this->z);
+    }
+
+    template<typename T>
+    Vec3Decimal<double> Vec3Int<T>::toDouble() const
+    {
+        return Vec3Decimal<double>((double)this->x, (double)this->y, (double)this->z);
+    }
+
+    template class Vec3Base<int, Vec3Int>;
+
+    template class Vec3Int<int>;
+}    
+
+
+
+
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SRCS
     Vec2i_Test.cpp
     Vec2d_Test.cpp
     Vec2f_Test.cpp
+    Vec3i_Test.cpp
 )
 
 include(FetchContent)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,8 @@ set(TEST_SRCS
     Vec2d_Test.cpp
     Vec2f_Test.cpp
     Vec3i_Test.cpp
+    Vec3f_Test.cpp
+    Vec3d_Test.cpp
 )
 
 include(FetchContent)

--- a/test/Vec3d_Test.cpp
+++ b/test/Vec3d_Test.cpp
@@ -1,0 +1,423 @@
+#include "pch.h"
+#include <VecPlus/Vec3.h>
+#include <iostream>
+
+// TODO: Add tests for Vec2d::rotation(char axis, double angle);
+
+using namespace vecp;
+
+namespace Vec3d_Tests
+{
+    TEST(Vec3d_TestConstructorDefault, SetDefaultValues)
+    {   
+        Vec3d vector = Vec3d();
+        ASSERT_DOUBLE_EQ(vector.x, 0.0);
+        ASSERT_DOUBLE_EQ(vector.y, 0.0);
+        ASSERT_DOUBLE_EQ(vector.z, 0.0);
+    }
+
+    // Constructor with specified values test
+    TEST(Vec3d_TestConstructorValues, SetSpecifiedValues)
+    {
+        Vec3d vector = Vec3d(-3.5, 4.2, 1.5);
+        ASSERT_DOUBLE_EQ(vector.x, -3.5);
+        ASSERT_DOUBLE_EQ(vector.y, 4.2);
+        ASSERT_DOUBLE_EQ(vector.z, 1.5);
+    }
+
+    class Vec3d_VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec3d, double, Vec3d>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vector = std::get<0>(GetParam());
+            scalar = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec3d vector, expected;
+        double scalar;
+    };
+
+    class Vec3d_VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec3d, Vec3d, Vec3d>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec3d vectorOne, vectorTwo, expected;
+    };
+
+    // Vec3d operator + (const Vec3d& vector) const
+    class Vec3d_AddVectorF : public Vec3d_VecVecVecFixture {};
+    TEST_P(Vec3d_AddVectorF, Vec3d_AddVector)
+    {
+        Vec3d output = vectorOne + vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);
+        ASSERT_DOUBLE_EQ(expected.z, output.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_AddVector, Vec3d_AddVectorF, testing::Values(
+        std::make_tuple(Vec3d(1.1, 2.2, 3.3), Vec3d(3.3, 4.4, 5.5), Vec3d(4.4, 6.6, 8.8)),
+        std::make_tuple(Vec3d(-2.5, 5.1, -1.1), Vec3d(7.2, -3.3, 2.2), Vec3d(4.7, 1.8, 1.1)),
+        std::make_tuple(Vec3d(0.0, -8.4, 7.7), Vec3d(-4.4, 6.6, -3.3), Vec3d(-4.4, -1.8, 4.4)),
+        std::make_tuple(Vec3d(10.0, -10.0, 5.0), Vec3d(-10.0, 10.0, -5.0), Vec3d(0.0, 0.0, 0.0))
+    ));
+
+    // void operator += (const Vec3d& vector)
+    class Vec3d_AddEqualsVectorF : public Vec3d_VecVecVecFixture {};
+    TEST_P(Vec3d_AddEqualsVectorF, Vec3d_AddEqualsVector)
+    {
+        vectorOne += vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
+        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);
+        ASSERT_DOUBLE_EQ(expected.z, vectorOne.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_AddEqualsVector, Vec3d_AddEqualsVectorF, testing::Values(
+        std::make_tuple(Vec3d(1.1, 2.2, 3.3), Vec3d(3.3, 4.4, 5.5), Vec3d(4.4, 6.6, 8.8)),
+        std::make_tuple(Vec3d(-2.5, 5.1, -1.1), Vec3d(7.2, -3.3, 2.2), Vec3d(4.7, 1.8, 1.1)),
+        std::make_tuple(Vec3d(0.0, -8.4, 7.7), Vec3d(-4.4, 6.6, -3.3), Vec3d(-4.4, -1.8, 4.4)),
+        std::make_tuple(Vec3d(10.0, -10.0, 5.0), Vec3d(-10.0, 10.0, -5.0), Vec3d(0.0, 0.0, 0.0))
+    ));
+
+    // Vec3d operator - (const Vec3d& vector) const
+    class Vec3d_SubtractVectorF : public Vec3d_VecVecVecFixture {};
+    TEST_P(Vec3d_SubtractVectorF, Vec3d_SubtractVector)
+    {
+        Vec3d output = vectorOne - vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);
+        ASSERT_DOUBLE_EQ(expected.z, output.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_SubtractVector, Vec3d_SubtractVectorF, testing::Values(
+        std::make_tuple(Vec3d(5.5, 7.7, 2.2), Vec3d(3.3, 2.2, 1.1), Vec3d(2.2, 5.5, 1.1)),
+        std::make_tuple(Vec3d(10.0, 10.0, 5.5), Vec3d(4.5, 6.5, 2.5), Vec3d(5.5, 3.5, 3.0)),
+        std::make_tuple(Vec3d(-3.3, 8.8, -4.4), Vec3d(2.2, -5.5, 1.1), Vec3d(-5.5, 14.3, -5.5)),
+        std::make_tuple(Vec3d(0.0, 0.0, 0.0), Vec3d(-7.7, 9.9, -1.1), Vec3d(7.7, -9.9, 1.1))
+    ));
+
+    // void operator -= (const Vec3d& vector)
+    class Vec3d_SubtractEqualsVectorF : public Vec3d_VecVecVecFixture {};
+    TEST_P(Vec3d_SubtractEqualsVectorF, Vec3d_SubtractEqualsVector)
+    {
+        vectorOne -= vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
+        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);
+        ASSERT_DOUBLE_EQ(expected.z, vectorOne.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_SubtractEqualsVector, Vec3d_SubtractEqualsVectorF, testing::Values(
+        std::make_tuple(Vec3d(5.5, 7.7, 2.2), Vec3d(3.3, 2.2, 1.1), Vec3d(2.2, 5.5, 1.1)),
+        std::make_tuple(Vec3d(10.0, 10.0, 5.5), Vec3d(4.5, 6.5, 2.5), Vec3d(5.5, 3.5, 3.0)),
+        std::make_tuple(Vec3d(-3.3, 8.8, -4.4), Vec3d(2.2, -5.5, 1.1), Vec3d(-5.5, 14.3, -5.5)),
+        std::make_tuple(Vec3d(0.0, 0.0, 0.0), Vec3d(-7.7, 9.9, -1.1), Vec3d(7.7, -9.9, 1.1))
+    ));
+
+    // Vec3d operator * (double scalar) const
+    class Vec3d_MultiplyByScalarF : public Vec3d_VecScaVecFixture {};
+    TEST_P(Vec3d_MultiplyByScalarF, Vec3d_MultiplyByScalar)
+    {
+        Vec3d output = vector * scalar;
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);   
+        ASSERT_DOUBLE_EQ(expected.z, output.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_MultiplyByScalar, Vec3d_MultiplyByScalarF, testing::Values(
+        std::make_tuple(Vec3d(0.0, 0.0, 0.0), 10.0, Vec3d(0.0, 0.0, 0.0)),
+        std::make_tuple(Vec3d(3.3, 4.4, 5.5), 10.0, Vec3d(33.0, 44.0, 55.0)),
+        std::make_tuple(Vec3d(-6.6, 4.4, -5.5), 5.0, Vec3d(-33.0, 22.0, -27.5)),
+        std::make_tuple(Vec3d(8.8, -7.7, 6.6), -5.0, Vec3d(-44.0, 38.5, -33.0))
+    ));
+
+    // Vec3d operator * (const Vec3d& vector) const
+    class Vec3d_MultiplyByVectorF : public Vec3d_VecVecVecFixture {};
+    TEST_P(Vec3d_MultiplyByVectorF, Vec3d_MultiplyByVector)
+    {
+        Vec3d output = vectorOne * vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);   
+        ASSERT_DOUBLE_EQ(expected.z, output.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_MultiplyByVector, Vec3d_MultiplyByVectorF, testing::Values(
+        std::make_tuple(Vec3d(0.0, 0.0, 0.0), Vec3d(10.0, 10.0, 10.0), Vec3d(0.0, 0.0, 0.0)),
+        std::make_tuple(Vec3d(3.3, 4.4, 5.5), Vec3d(5.5, 10.0, 2.0), Vec3d(18.15, 44.0, 11.0)),
+        std::make_tuple(Vec3d(-6.6, 4.4, -3.3), Vec3d(5.5, -5.0, 7.0), Vec3d(-36.3, -22.0, -23.1)),
+        std::make_tuple(Vec3d(8.8, -7.7, 6.6), Vec3d(-5.5, -5.5, 3.3), Vec3d(-48.4, 42.35, 21.78))
+    ));
+
+    // void operator *= (double scalar)
+    class Vec3d_MultiplyEqualsByScalarF : public Vec3d_VecScaVecFixture {};
+    TEST_P(Vec3d_MultiplyEqualsByScalarF, Vec3d_MultiplyEqualsByScalar)
+    {
+        vector *= scalar;
+        ASSERT_DOUBLE_EQ(expected.x, vector.x);
+        ASSERT_DOUBLE_EQ(expected.y, vector.y);   
+        ASSERT_DOUBLE_EQ(expected.z, vector.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_MultiplyEqualsByScalar,Vec3d_MultiplyEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec3d(0.0, 0.0, 0.0), 10.0, Vec3d(0.0, 0.0, 0.0)),
+        std::make_tuple(Vec3d(3.3, 4.4, 5.5), 10.0, Vec3d(33.0, 44.0, 55.0)),
+        std::make_tuple(Vec3d(-6.6, 4.4, -5.5), 5.0, Vec3d(-33.0, 22.0, -27.5)),
+        std::make_tuple(Vec3d(8.8, -7.7, 6.6), -5.0, Vec3d(-44.0, 38.5, -33.0))
+    ));
+
+    // void operator *= (const Vec3d& vector)
+    class Vec3d_MultiplyEqualsByVectorF : public Vec3d_VecVecVecFixture {};
+    TEST_P(Vec3d_MultiplyEqualsByVectorF, MultiplyEqualsByVector)
+    {
+        vectorOne *= vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
+        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);   
+        ASSERT_DOUBLE_EQ(expected.z, vectorOne.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_MultiplyEqualsByVector, Vec3d_MultiplyEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec3d(0.0, 0.0, 0.0), Vec3d(10.0, 10.0, 10.0), Vec3d(0.0, 0.0, 0.0)),
+        std::make_tuple(Vec3d(3.3, 4.4, 5.5), Vec3d(5.5, 10.0, 2.0), Vec3d(18.15, 44.0, 11.0)),
+        std::make_tuple(Vec3d(-6.6, 4.4, -3.3), Vec3d(5.5, -5.0, 7.0), Vec3d(-36.3, -22.0, -23.1)),
+        std::make_tuple(Vec3d(8.8, -7.7, 6.6), Vec3d(-5.5, -5.5, 3.3), Vec3d(-48.4, 42.35, 21.78))
+    ));
+
+    class Vec3d_VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec3d, Vec3d, bool>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec3d vectorOne, vectorTwo;
+        bool expected;
+    };
+
+    // bool operator == (const Vec3d& vector) const
+    class Vec3d_CompareVectorsF : public Vec3d_VecVecBoolFixture {};
+    TEST_P(Vec3d_CompareVectorsF, CompareVectors)
+    {
+        bool output = vectorOne == vectorTwo;
+        ASSERT_EQ(expected, output);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_CompareVectors, Vec3d_CompareVectorsF, testing::Values(
+        std::make_tuple(Vec3d(-5.5, 5.5, 0.0), Vec3d(-5.5, 5.5, 0.0), true),
+        std::make_tuple(Vec3d(0.0, 0.0, 0.0), Vec3d(0.0, 0.0, 0.0), true),
+        std::make_tuple(Vec3d(-5.5, 5.5, 5.5), Vec3d(5.5, -5.5, 5.5), false),
+        std::make_tuple(Vec3d(6.1, 0.0, 7.1), Vec3d(7.1, 0.0, 6.1), false)
+    ));
+
+    class Vec3d_VecVecScaFixture : public testing::TestWithParam<std::tuple<Vec3d, Vec3d, double>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec3d vectorOne, vectorTwo;
+        double expected;
+    };
+
+    // double mag() const
+    class Vec3d_MagnitudeF : public Vec3d_VecVecScaFixture {};
+    TEST_P(Vec3d_MagnitudeF, Vec3d_Magnitude)
+    {
+        double output = vectorOne.mag();
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_Magnitude, Vec3d_MagnitudeF, testing::Values(
+        std::make_tuple(Vec3d(5.0, 4.0, 3.0), Vec3d(0.0, 0.0, 0.0), 7.07106781),
+        std::make_tuple(Vec3d(-8.2, 0.6, -2.5), Vec3d(0.0, 0.0, 0.0), 8.593602271),
+        std::make_tuple(Vec3d(-8.2, -0.6, 2.5), Vec3d(0.0, 0.0, 0.0), 8.593602271)
+    ));
+
+    // double mag(const Vec3d& vector) const
+    class Vec3d_MagnitudeVectorF : public Vec3d_VecVecScaFixture {};
+    TEST_P(Vec3d_MagnitudeVectorF, Vec3d_MagnitudeVector)
+    {
+        double output = vectorOne.mag(vectorTwo);
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_MagnitudeVector, Vec3d_MagnitudeVectorF, testing::Values(
+        std::make_tuple(Vec3d(5.0, 4.0, 3.0), Vec3d(0.0, 0.0, 0.0), 7.07106781),
+        std::make_tuple(Vec3d(0.0, 0.0, 0.0), Vec3d(5.0, 4.0, 3.0), 7.07106781),
+        std::make_tuple(Vec3d(-8.2, 0.6, -2.5), Vec3d(5.9, 4.6, 1.3), 15.14100393),
+        std::make_tuple(Vec3d(-8.2, -0.6, 2.5), Vec3d(-5.9, -4.6, 1.3), 4.767598976)
+    ));
+
+    // Vec3d operator / (double scalar) const
+    class Vec3d_DivideByScalarF : public Vec3d_VecScaVecFixture {};
+    TEST_P(Vec3d_DivideByScalarF, Vec3d_DivideByScalar)
+    {
+        Vec3d output = vector / scalar;
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);   
+        ASSERT_DOUBLE_EQ(expected.z, output.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_DivideByScalar, Vec3d_DivideByScalarF, testing::Values(
+        std::make_tuple(Vec3d(10.0, 20.0, 30.0), 2.0, Vec3d(5.0, 10.0, 15.0)),
+        std::make_tuple(Vec3d(-6.6, 4.4, -2.2), -2.2, Vec3d(3.0, -2.0, 1.0)),
+        std::make_tuple(Vec3d(10.0, -5.0, 2.5), 2.0, Vec3d(5.0, -2.5, 1.25)),
+        std::make_tuple(Vec3d(8.8, -7.7, 6.6), 4.4, Vec3d(2.0, -1.75, 1.5)),
+        std::make_tuple(Vec3d(9.0, 12.0, 15.0), 3.0, Vec3d(3.0, 4.0, 5.0))  
+    ));
+
+    // Vec3d operator / (const Vec3d& vector) const
+    class Vec3d_DivideByVectorF : public Vec3d_VecVecVecFixture {};
+    TEST_P(Vec3d_DivideByVectorF, Vec3d_DivideByVector)
+    {
+        Vec3d output = vectorOne / vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, output.x);
+        ASSERT_DOUBLE_EQ(expected.y, output.y);   
+        ASSERT_DOUBLE_EQ(expected.z, output.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_DivideByVector, Vec3d_DivideByVectorF, testing::Values(
+        std::make_tuple(Vec3d(10.0, 20.0, 30.0), Vec3d(2.0, 4.0, 6.0), Vec3d(5.0, 5.0, 5.0)),
+        std::make_tuple(Vec3d(-6.6, 4.4, -2.2), Vec3d(-2.2, 2.2, 1.1), Vec3d(3.0, 2.0, -2.0)),
+        std::make_tuple(Vec3d(10.0, -5.0, 2.5), Vec3d(2.0, -5.0, 0.5), Vec3d(5.0, 1.0, 5.0)),
+        std::make_tuple(Vec3d(8.8, -7.7, 6.6), Vec3d(4.4, -7.7, 3.3), Vec3d(2.0, 1.0, 2.0))
+    ));
+
+    // void operator /= (double scalar)
+    class Vec3d_DivideEqualsByScalarF : public Vec3d_VecScaVecFixture {};
+    TEST_P(Vec3d_DivideEqualsByScalarF, Vec3d_DivideEqualsByScalar)
+    {
+        vector /= scalar;
+        ASSERT_DOUBLE_EQ(expected.x, vector.x);
+        ASSERT_DOUBLE_EQ(expected.y, vector.y);   
+        ASSERT_DOUBLE_EQ(expected.z, vector.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_DivideEqualsByScalar, Vec3d_DivideEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec3d(10.0, 20.0, 30.0), 2.0, Vec3d(5.0, 10.0, 15.0)),
+        std::make_tuple(Vec3d(-6.6, 4.4, -2.2), -2.2, Vec3d(3.0, -2.0, 1.0)),
+        std::make_tuple(Vec3d(10.0, -5.0, 2.5), 2.0, Vec3d(5.0, -2.5, 1.25)),
+        std::make_tuple(Vec3d(8.8, -7.7, 6.6), 4.4, Vec3d(2.0, -1.75, 1.5))
+    ));
+
+    // void operator /= (const Vec3d& vector)
+    class Vec3d_DivideEqualsByVectorF : public Vec3d_VecVecVecFixture {};
+    TEST_P(Vec3d_DivideEqualsByVectorF, Vec3d_DivideEqualsByVector)
+    {
+        vectorOne /= vectorTwo;
+        ASSERT_DOUBLE_EQ(expected.x, vectorOne.x);
+        ASSERT_DOUBLE_EQ(expected.y, vectorOne.y);   
+        ASSERT_DOUBLE_EQ(expected.z, vectorOne.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_DivideEqualsByVector, Vec3d_DivideEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec3d(10.0, 20.0, 30.0), Vec3d(2.0, 4.0, 6.0), Vec3d(5.0, 5.0, 5.0)),
+        std::make_tuple(Vec3d(-6.6, 4.4, -2.2), Vec3d(-2.2, 2.2, 1.1), Vec3d(3.0, 2.0, -2.0)),
+        std::make_tuple(Vec3d(10.0, -5.0, 2.5), Vec3d(2.0, -5.0, 0.5), Vec3d(5.0, 1.0, 5.0)),
+        std::make_tuple(Vec3d(8.8, -7.7, 6.6), Vec3d(4.4, -7.7, 3.3), Vec3d(2.0, 1.0, 2.0))
+    ));
+
+    // double Vec3d::dot(const Vec3d& vector) const
+    class Vec3d_DotVectorF : public Vec3d_VecVecScaFixture {};
+    TEST_P(Vec3d_DotVectorF, Vec3d_DotVector)
+    {
+        double output = vectorOne.dot(vectorTwo);
+        ASSERT_NEAR(expected, output, 1E-05);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_DotVector, Vec3d_DotVectorF, testing::Values(
+        std::make_tuple(Vec3d(5., 4., 3.), Vec3d(6.2, 2., 1.1), 42.3),
+        std::make_tuple(Vec3d(-5., -4., -3.), Vec3d(-6.2, 3., 1.1), 15.7),
+        std::make_tuple(Vec3d(-5., 4., 3.), Vec3d(6.2, 1., -1.1), -30.3),
+        std::make_tuple(Vec3d(5., -4., 3.), Vec3d(6.2, -2.5, 1.1), 44.3)
+    ));
+
+    // double Vec3d::dot(double scalar) const
+    class Vec3d_DotScalarF : public Vec3d_VecVecScaFixture {};
+    TEST_P(Vec3d_DotScalarF, Vec3d_DotScalar)
+    {
+        double output = vectorOne.dot(vectorTwo.x);
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_DotScalar, Vec3d_DotScalarF, testing::Values(
+        std::make_tuple(Vec3d(5., 4., 3.), Vec3d(6.2, 0., 0.), 74.4),
+        std::make_tuple(Vec3d(-5., -4., -3.), Vec3d(-6.2, 0., 0.), 74.4),
+        std::make_tuple(Vec3d(-5., 4., 3.), Vec3d(0., 0., 0.), 0.),
+        std::make_tuple(Vec3d(5., -4., 3.), Vec3d(-1.1, 0., 0.), -4.4)
+    ));
+
+
+    // double Vec3d::dot(double xTwo, double yTwo, double zTwo) const
+    class Vec3d_DotScalarScalarF : public Vec3d_VecVecScaFixture {};
+    TEST_P(Vec3d_DotScalarScalarF, Vec3d_DotScalarScalar)
+    {
+        double output = vectorOne.dot(vectorTwo.x, vectorTwo.y, vectorTwo.z);
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_DotScalarScalar, Vec3d_DotScalarScalarF, testing::Values(
+        std::make_tuple(Vec3d(5., 4., 3.), Vec3d(6.2, 2., 1.1), 42.3),
+        std::make_tuple(Vec3d(-5., -4., -3.), Vec3d(-6.2, 3., 1.1), 15.7),
+        std::make_tuple(Vec3d(-5., 4., 3.), Vec3d(6.2, 1., -1.1), -30.3),
+        std::make_tuple(Vec3d(5., -4., 3.), Vec3d(6.2, -2.5, 1.1), 44.3)
+    ));
+
+    // Vec3d Vec3d::normalize() const
+    class Vec3d_NormaliseF : public Vec3d_VecVecVecFixture {};
+    TEST_P(Vec3d_NormaliseF, Vec3d_Normalise)
+    {
+        Vec3d output = vectorOne.normalise();
+        ASSERT_NEAR(expected.x, output.x, 1E-05);
+        ASSERT_NEAR(expected.y, output.y, 1E-05);
+        ASSERT_NEAR(expected.z, output.z, 1E-05);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_Normalise, Vec3d_NormaliseF, testing::Values(
+        std::make_tuple(Vec3d(5.0, 5.0, 5.0), Vec3d(0.0, 0.0, 0.0), Vec3d(0.57735, 0.57735, 0.57735)),
+        std::make_tuple(Vec3d(-5.0, -5.0, -5.0), Vec3d(0.0, 0.0, 0.0), Vec3d(-0.57735, -0.57735, -0.57735)),
+        std::make_tuple(Vec3d(-6.0, 8.0, -10.0), Vec3d(0.0, 0.0, 0.0), Vec3d(-0.42426, 0.56569, -0.70711))
+    ));
+
+    class Vec3d_VecDoubleDoubleFixture : public testing::TestWithParam<std::tuple<Vec3d, double, double, double>>
+    {
+        protected:
+            void SetUp() override
+            {
+                vector = std::get<0>(GetParam());
+                expectedX = std::get<1>(GetParam());
+                expectedY = std::get<2>(GetParam());
+                expectedZ = std::get<3>(GetParam());
+            }
+            Vec3d vector;
+            double expectedX, expectedY, expectedZ;
+    };
+
+    // Vec3d Vec3d::toDouble() const
+    class Vec3d_ConvertToDoubleF : public Vec3d_VecDoubleDoubleFixture {};
+    TEST_P(Vec3d_ConvertToDoubleF, Vec3d_ConvertToDouble)
+    { 
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().x));
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().y));   
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().z));   
+        ASSERT_DOUBLE_EQ(expectedX, vector.toDouble().x);
+        ASSERT_DOUBLE_EQ(expectedY, vector.toDouble().y);   
+        ASSERT_DOUBLE_EQ(expectedZ, vector.toDouble().z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3d_ConvertToDouble, Vec3d_ConvertToDoubleF, testing::Values(
+        std::make_tuple(Vec3d(0.0, 0.0, 0.0), 0.0, 0.0, 0.0),
+        std::make_tuple(Vec3d(5.2, 5.2, 5.2), 5.2, 5.2, 5.2),
+        std::make_tuple(Vec3d(-5.2, -5.2, -5.2), -5.2, -5.2, -5.2),
+        std::make_tuple(Vec3d(10.09, -10.09, 20.18), 10.09, -10.09, 20.18)
+    ));
+
+}

--- a/test/Vec3f_Test.cpp
+++ b/test/Vec3f_Test.cpp
@@ -1,0 +1,446 @@
+#include "pch.h"
+#include <VecPlus/Vec3.h>
+#include <iostream>
+
+// TODO: Add tests for Vec2f::rotation(char axis, float angle);
+
+using namespace vecp;
+
+namespace Vec3f_Tests
+{
+    TEST(Vec3f_TestConstructorDefault, SetDefaultValues)
+    {   
+        Vec3f vector = Vec3f();
+        ASSERT_FLOAT_EQ(vector.x, 0.0f);
+        ASSERT_FLOAT_EQ(vector.y, 0.0f);
+        ASSERT_FLOAT_EQ(vector.z, 0.0f);
+    }
+
+    // Constructor with specified values test
+    TEST(Vec3f_TestConstructorValues, SetSpecifiedValues)
+    {
+        Vec3f vector = Vec3f(-3.5f, 4.2f, 1.5f);
+        ASSERT_FLOAT_EQ(vector.x, -3.5f);
+        ASSERT_FLOAT_EQ(vector.y, 4.2f);
+        ASSERT_FLOAT_EQ(vector.z, 1.5f);
+    }
+
+    class Vec3f_VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec3f, float, Vec3f>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vector = std::get<0>(GetParam());
+            scalar = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec3f vector, expected;
+        float scalar;
+    };
+
+    class Vec3f_VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec3f, Vec3f, Vec3f>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec3f vectorOne, vectorTwo, expected;
+    };
+
+    // Vec3f operator + (const Vec3f& vector) const
+    class Vec3f_AddVectorF : public Vec3f_VecVecVecFixture {};
+    TEST_P(Vec3f_AddVectorF, Vec3f_AddVector)
+    {
+        Vec3f output = vectorOne + vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);
+        ASSERT_FLOAT_EQ(expected.z, output.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_AddVector, Vec3f_AddVectorF, testing::Values(
+        std::make_tuple(Vec3f(1.1f, 2.2f, 3.3f), Vec3f(3.3f, 4.4f, 5.5f), Vec3f(4.4f, 6.6f, 8.8f)),
+        std::make_tuple(Vec3f(-2.5f, 5.1f, -1.1f), Vec3f(7.2f, -3.3f, 2.2f), Vec3f(4.7f, 1.8f, 1.1f)),
+        std::make_tuple(Vec3f(0.0f, -8.4f, 7.7f), Vec3f(-4.4f, 6.6f, -3.3f), Vec3f(-4.4f, -1.8f, 4.4f)),
+        std::make_tuple(Vec3f(10.0f, -10.0f, 5.0f), Vec3f(-10.0f, 10.0f, -5.0f), Vec3f(0.0f, 0.0f, 0.0f))
+    ));
+
+    // void operator += (const Vec3f& vector)
+    class Vec3f_AddEqualsVectorF : public Vec3f_VecVecVecFixture {};
+    TEST_P(Vec3f_AddEqualsVectorF, Vec3f_AddEqualsVector)
+    {
+        vectorOne += vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, vectorOne.x);
+        ASSERT_FLOAT_EQ(expected.y, vectorOne.y);
+        ASSERT_FLOAT_EQ(expected.z, vectorOne.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_AddEqualsVector, Vec3f_AddEqualsVectorF, testing::Values(
+        std::make_tuple(Vec3f(1.1f, 2.2f, 3.3f), Vec3f(3.3f, 4.4f, 5.5f), Vec3f(4.4f, 6.6f, 8.8f)),
+        std::make_tuple(Vec3f(-2.5f, 5.1f, -1.1f), Vec3f(7.2f, -3.3f, 2.2f), Vec3f(4.7f, 1.8f, 1.1f)),
+        std::make_tuple(Vec3f(0.0f, -8.4f, 7.7f), Vec3f(-4.4f, 6.6f, -3.3f), Vec3f(-4.4f, -1.8f, 4.4f)),
+        std::make_tuple(Vec3f(10.0f, -10.0f, 5.0f), Vec3f(-10.0f, 10.0f, -5.0f), Vec3f(0.0f, 0.0f, 0.0f))
+    ));
+
+    // Vec3f operator - (const Vec3f& vector) const
+    class Vec3f_SubtractVectorF : public Vec3f_VecVecVecFixture {};
+    TEST_P(Vec3f_SubtractVectorF, Vec3f_SubtractVector)
+    {
+        Vec3f output = vectorOne - vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);
+        ASSERT_FLOAT_EQ(expected.z, output.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_SubtractVector, Vec3f_SubtractVectorF, testing::Values(
+        std::make_tuple(Vec3f(5.5f, 7.7f, 2.2f), Vec3f(3.3f, 2.2f, 1.1f), Vec3f(2.2f, 5.5f, 1.1f)),
+        std::make_tuple(Vec3f(10.0f, 10.0f, 5.5f), Vec3f(4.5f, 6.5f, 2.5f), Vec3f(5.5f, 3.5f, 3.0f)),
+        std::make_tuple(Vec3f(-3.3f, 8.8f, -4.4f), Vec3f(2.2f, -5.5f, 1.1f), Vec3f(-5.5f, 14.3f, -5.5f)),
+        std::make_tuple(Vec3f(0.0f, 0.0f, 0.0f), Vec3f(-7.7f, 9.9f, -1.1f), Vec3f(7.7f, -9.9f, 1.1f))
+    ));
+
+    // void operator -= (const Vec3f& vector)
+    class Vec3f_SubtractEqualsVectorF : public Vec3f_VecVecVecFixture {};
+    TEST_P(Vec3f_SubtractEqualsVectorF, Vec3f_SubtractEqualsVector)
+    {
+        vectorOne -= vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, vectorOne.x);
+        ASSERT_FLOAT_EQ(expected.y, vectorOne.y);
+        ASSERT_FLOAT_EQ(expected.z, vectorOne.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_SubtractEqualsVector, Vec3f_SubtractEqualsVectorF, testing::Values(
+        std::make_tuple(Vec3f(5.5f, 7.7f, 2.2f), Vec3f(3.3f, 2.2f, 1.1f), Vec3f(2.2f, 5.5f, 1.1f)),
+        std::make_tuple(Vec3f(10.0f, 10.0f, 5.5f), Vec3f(4.5f, 6.5f, 2.5f), Vec3f(5.5f, 3.5f, 3.0f)),
+        std::make_tuple(Vec3f(-3.3f, 8.8f, -4.4f), Vec3f(2.2f, -5.5f, 1.1f), Vec3f(-5.5f, 14.3f, -5.5f)),
+        std::make_tuple(Vec3f(0.0f, 0.0f, 0.0f), Vec3f(-7.7f, 9.9f, -1.1f), Vec3f(7.7f, -9.9f, 1.1f))
+    ));
+
+    // Vec3f operator * (float scalar) const
+    class Vec3f_MultiplyByScalarF : public Vec3f_VecScaVecFixture {};
+    TEST_P(Vec3f_MultiplyByScalarF, Vec3f_MultiplyByScalar)
+    {
+        Vec3f output = vector * scalar;
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);   
+        ASSERT_FLOAT_EQ(expected.z, output.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_MultiplyByScalar, Vec3f_MultiplyByScalarF, testing::Values(
+        std::make_tuple(Vec3f(0.0f, 0.0f, 0.0f), 10.0f, Vec3f(0.0f, 0.0f, 0.0f)),
+        std::make_tuple(Vec3f(3.3f, 4.4f, 5.5f), 10.0f, Vec3f(33.0f, 44.0f, 55.0f)),
+        std::make_tuple(Vec3f(-6.6f, 4.4f, -5.5f), 5.0f, Vec3f(-33.0f, 22.0f, -27.5f)),
+        std::make_tuple(Vec3f(8.8f, -7.7f, 6.6f), -5.0f, Vec3f(-44.0f, 38.5f, -33.0f))
+    ));
+
+    // Vec3f operator * (const Vec3f& vector) const
+    class Vec3f_MultiplyByVectorF : public Vec3f_VecVecVecFixture {};
+    TEST_P(Vec3f_MultiplyByVectorF, Vec3f_MultiplyByVector)
+    {
+        Vec3f output = vectorOne * vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);   
+        ASSERT_FLOAT_EQ(expected.z, output.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_MultiplyByVector, Vec3f_MultiplyByVectorF, testing::Values(
+        std::make_tuple(Vec3f(0.0f, 0.0f, 0.0f), Vec3f(10.0f, 10.0f, 10.0f), Vec3f(0.0f, 0.0f, 0.0f)),
+        std::make_tuple(Vec3f(3.3f, 4.4f, 5.5f), Vec3f(5.5f, 10.0f, 2.0f), Vec3f(18.15f, 44.0f, 11.0f)),
+        std::make_tuple(Vec3f(-6.6f, 4.4f, -3.3f), Vec3f(5.5f, -5.0f, 7.0f), Vec3f(-36.3f, -22.0f, -23.1f)),
+        std::make_tuple(Vec3f(8.8f, -7.7f, 6.6f), Vec3f(-5.5f, -5.5f, 3.3f), Vec3f(-48.4f, 42.35f, 21.78f))
+    ));
+
+    // void operator *= (float scalar)
+    class Vec3f_MultiplyEqualsByScalarF : public Vec3f_VecScaVecFixture {};
+    TEST_P(Vec3f_MultiplyEqualsByScalarF, Vec3f_MultiplyEqualsByScalar)
+    {
+        vector *= scalar;
+        ASSERT_FLOAT_EQ(expected.x, vector.x);
+        ASSERT_FLOAT_EQ(expected.y, vector.y);   
+        ASSERT_FLOAT_EQ(expected.z, vector.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_MultiplyEqualsByScalar,Vec3f_MultiplyEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec3f(0.0f, 0.0f, 0.0f), 10.0f, Vec3f(0.0f, 0.0f, 0.0f)),
+        std::make_tuple(Vec3f(3.3f, 4.4f, 5.5f), 10.0f, Vec3f(33.0f, 44.0f, 55.0f)),
+        std::make_tuple(Vec3f(-6.6f, 4.4f, -5.5f), 5.0f, Vec3f(-33.0f, 22.0f, -27.5f)),
+        std::make_tuple(Vec3f(8.8f, -7.7f, 6.6f), -5.0f, Vec3f(-44.0f, 38.5f, -33.0f))
+    ));
+
+    // void operator *= (const Vec3f& vector)
+    class Vec3f_MultiplyEqualsByVectorF : public Vec3f_VecVecVecFixture {};
+    TEST_P(Vec3f_MultiplyEqualsByVectorF, MultiplyEqualsByVector)
+    {
+        vectorOne *= vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, vectorOne.x);
+        ASSERT_FLOAT_EQ(expected.y, vectorOne.y);   
+        ASSERT_FLOAT_EQ(expected.z, vectorOne.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_MultiplyEqualsByVector, Vec3f_MultiplyEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec3f(0.0f, 0.0f, 0.0f), Vec3f(10.0f, 10.0f, 10.0f), Vec3f(0.0f, 0.0f, 0.0f)),
+        std::make_tuple(Vec3f(3.3f, 4.4f, 5.5f), Vec3f(5.5f, 10.0f, 2.0f), Vec3f(18.15f, 44.0f, 11.0f)),
+        std::make_tuple(Vec3f(-6.6f, 4.4f, -3.3f), Vec3f(5.5f, -5.0f, 7.0f), Vec3f(-36.3f, -22.0f, -23.1f)),
+        std::make_tuple(Vec3f(8.8f, -7.7f, 6.6f), Vec3f(-5.5f, -5.5f, 3.3f), Vec3f(-48.4f, 42.35f, 21.78f))
+    ));
+
+    class Vec3f_VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec3f, Vec3f, bool>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec3f vectorOne, vectorTwo;
+        bool expected;
+    };
+
+    // bool operator == (const Vec3f& vector) const
+    class Vec3f_CompareVectorsF : public Vec3f_VecVecBoolFixture {};
+    TEST_P(Vec3f_CompareVectorsF, CompareVectors)
+    {
+        bool output = vectorOne == vectorTwo;
+        ASSERT_EQ(expected, output);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_CompareVectors, Vec3f_CompareVectorsF, testing::Values(
+        std::make_tuple(Vec3f(-5.5f, 5.5f, 0.0f), Vec3f(-5.5f, 5.5f, 0.0f), true),
+        std::make_tuple(Vec3f(0.0f, 0.0f, 0.0f), Vec3f(0.0f, 0.0f, 0.0f), true),
+        std::make_tuple(Vec3f(-5.5f, 5.5f, 5.5f), Vec3f(5.5f, -5.5f, 5.5f), false),
+        std::make_tuple(Vec3f(6.1f, 0.0f, 7.1f), Vec3f(7.1f, 0.0f, 6.1f), false)
+    ));
+
+    class Vec3f_VecVecScaFixture : public testing::TestWithParam<std::tuple<Vec3f, Vec3f, float>>
+    {
+    protected:
+        void SetUp() override
+        {
+            vectorOne = std::get<0>(GetParam());
+            vectorTwo = std::get<1>(GetParam());
+            expected = std::get<2>(GetParam());
+        }
+        Vec3f vectorOne, vectorTwo;
+        float expected;
+    };
+
+    // float mag() const
+    class Vec3f_MagnitudeF : public Vec3f_VecVecScaFixture {};
+    TEST_P(Vec3f_MagnitudeF, Vec3f_Magnitude)
+    {
+        float output = vectorOne.mag();
+        ASSERT_FLOAT_EQ(expected, output);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_Magnitude, Vec3f_MagnitudeF, testing::Values(
+        std::make_tuple(Vec3f(5.f, 4.f, 3.f), Vec3f(0.f, 0.f, 0.f), 7.07106781f),
+        std::make_tuple(Vec3f(-8.2f, 0.6f, -2.5f), Vec3f(0.f, 0.f, 0.f), 8.593602271f),
+        std::make_tuple(Vec3f(-8.2f, -0.6f, 2.5f), Vec3f(0.f, 0.f, 0.f), 8.593602271f)
+    ));
+
+    // float mag(const Vec3f& vector) const
+    class Vec3f_MagnitudeVectorF : public Vec3f_VecVecScaFixture {};
+    TEST_P(Vec3f_MagnitudeVectorF, Vec3f_MagnitudeVector)
+    {
+        float output = vectorOne.mag(vectorTwo);
+        ASSERT_NEAR(expected, output, 1E-05);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_MagnitudeVector, Vec3f_MagnitudeVectorF, testing::Values(
+        std::make_tuple(Vec3f(5.f, 4.f, 3.f), Vec3f(0.f, 0.f, 0.f), 7.07106781f),
+        std::make_tuple(Vec3f(0.f, 0.f, 0.0f), Vec3f(5.f, 4.f, 3.f), 7.07106781f),
+        std::make_tuple(Vec3f(-8.2f, 0.6f, -2.5f), Vec3f(5.9f, 4.6f, 1.3f), 15.14100393f),
+        std::make_tuple(Vec3f(-8.2f, -0.6f, 2.5f), Vec3f(-5.9f, -4.6f, 1.3f), 4.767598976f)
+    ));
+
+    // Vec3f operator / (float scalar) const
+    class Vec3f_DivideByScalarF : public Vec3f_VecScaVecFixture {};
+    TEST_P(Vec3f_DivideByScalarF, Vec3f_DivideByScalar)
+    {
+        Vec3f output = vector / scalar;
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);   
+        ASSERT_FLOAT_EQ(expected.z, output.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_DivideByScalar, Vec3f_DivideByScalarF, testing::Values(
+        std::make_tuple(Vec3f(10.0f, 20.0f, 30.0f), 2.0f, Vec3f(5.0f, 10.0f, 15.0f)),
+        std::make_tuple(Vec3f(-6.6f, 4.4f, -2.2f), -2.2f, Vec3f(3.0f, -2.0f, 1.0f)),
+        std::make_tuple(Vec3f(10.0f, -5.0f, 2.5f), 2.0f, Vec3f(5.0f, -2.5f, 1.25f)),
+        std::make_tuple(Vec3f(8.8f, -7.7f, 6.6f), 4.4f, Vec3f(2.0f, -1.75f, 1.5f)),
+        std::make_tuple(Vec3f(9.0f, 12.0f, 15.0f), 3.0f, Vec3f(3.0f, 4.0f, 5.0f))  
+    ));
+
+    // Vec3f operator / (const Vec3f& vector) const
+    class Vec3f_DivideByVectorF : public Vec3f_VecVecVecFixture {};
+    TEST_P(Vec3f_DivideByVectorF, Vec3f_DivideByVector)
+    {
+        Vec3f output = vectorOne / vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, output.x);
+        ASSERT_FLOAT_EQ(expected.y, output.y);   
+        ASSERT_FLOAT_EQ(expected.z, output.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_DivideByVector, Vec3f_DivideByVectorF, testing::Values(
+        std::make_tuple(Vec3f(10.0f, 20.0f, 30.0f), Vec3f(2.0f, 4.0f, 6.0f), Vec3f(5.0f, 5.0f, 5.0f)),
+        std::make_tuple(Vec3f(-6.6f, 4.4f, -2.2f), Vec3f(-2.2f, 2.2f, 1.1f), Vec3f(3.0f, 2.0f, -2.0f)),
+        std::make_tuple(Vec3f(10.0f, -5.0f, 2.5f), Vec3f(2.0f, -5.0f, 0.5f), Vec3f(5.0f, 1.0f, 5.0f)),
+        std::make_tuple(Vec3f(8.8f, -7.7f, 6.6f), Vec3f(4.4f, -7.7f, 3.3f), Vec3f(2.0f, 1.0f, 2.0f))
+    ));
+
+    // void operator /= (float scalar)
+    class Vec3f_DivideEqualsByScalarF : public Vec3f_VecScaVecFixture {};
+    TEST_P(Vec3f_DivideEqualsByScalarF, Vec3f_DivideEqualsByScalar)
+    {
+        vector /= scalar;
+        ASSERT_FLOAT_EQ(expected.x, vector.x);
+        ASSERT_FLOAT_EQ(expected.y, vector.y);   
+        ASSERT_FLOAT_EQ(expected.z, vector.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_DivideEqualsByScalar, Vec3f_DivideEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec3f(10.0f, 20.0f, 30.0f), 2.0f, Vec3f(5.0f, 10.0f, 15.0f)),
+        std::make_tuple(Vec3f(-6.6f, 4.4f, -2.2f), -2.2f, Vec3f(3.0f, -2.0f, 1.0f)),
+        std::make_tuple(Vec3f(10.0f, -5.0f, 2.5f), 2.0f, Vec3f(5.0f, -2.5f, 1.25f)),
+        std::make_tuple(Vec3f(8.8f, -7.7f, 6.6f), 4.4f, Vec3f(2.0f, -1.75f, 1.5f))
+    ));
+
+    // void operator /= (const Vec3f& vector)
+    class Vec3f_DivideEqualsByVectorF : public Vec3f_VecVecVecFixture {};
+    TEST_P(Vec3f_DivideEqualsByVectorF, Vec3f_DivideEqualsByVector)
+    {
+        vectorOne /= vectorTwo;
+        ASSERT_FLOAT_EQ(expected.x, vectorOne.x);
+        ASSERT_FLOAT_EQ(expected.y, vectorOne.y);   
+        ASSERT_FLOAT_EQ(expected.z, vectorOne.z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_DivideEqualsByVector, Vec3f_DivideEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec3f(10.0f, 20.0f, 30.0f), Vec3f(2.0f, 4.0f, 6.0f), Vec3f(5.0f, 5.0f, 5.0f)),
+        std::make_tuple(Vec3f(-6.6f, 4.4f, -2.2f), Vec3f(-2.2f, 2.2f, 1.1f), Vec3f(3.0f, 2.0f, -2.0f)),
+        std::make_tuple(Vec3f(10.0f, -5.0f, 2.5f), Vec3f(2.0f, -5.0f, 0.5f), Vec3f(5.0f, 1.0f, 5.0f)),
+        std::make_tuple(Vec3f(8.8f, -7.7f, 6.6f), Vec3f(4.4f, -7.7f, 3.3f), Vec3f(2.0f, 1.0f, 2.0f))
+    ));
+
+    // float Vec3f::dot(const Vec3f& vector) const
+    class Vec3f_DotVectorF : public Vec3f_VecVecScaFixture {};
+    TEST_P(Vec3f_DotVectorF, Vec3f_DotVector)
+    {
+        float output = vectorOne.dot(vectorTwo);
+        ASSERT_NEAR(expected, output, 1E-05);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_DotVector, Vec3f_DotVectorF, testing::Values(
+        std::make_tuple(Vec3f(5.f, 4.f, 3.f), Vec3f(6.2f, 2.f, 1.1f), 42.3f),
+        std::make_tuple(Vec3f(-5.f, -4.f, -3.f), Vec3f(-6.2f, 3.f, 1.1f), 15.7f),
+        std::make_tuple(Vec3f(-5.f, 4.f, 3.f), Vec3f(6.2f, 1.f, -1.1f), -30.3f),
+        std::make_tuple(Vec3f(5.f, -4.f, 3.f), Vec3f(6.2f, -2.5f, 1.1f), 44.3f)
+    ));
+
+    // double Vec3d::dot(double scalar) const
+    class Vec3f_DotScalarF : public Vec3f_VecVecScaFixture {};
+    TEST_P(Vec3f_DotScalarF, Vec3f_DotScalar)
+    {
+        float output = vectorOne.dot(vectorTwo.x);
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_DotScalar, Vec3f_DotScalarF, testing::Values(
+        std::make_tuple(Vec3f(5.f, 4.f, 3.f), Vec3f(6.2f, 0.f, 0.f), 74.4f),
+        std::make_tuple(Vec3f(-5.f, -4.f, -3.f), Vec3f(-6.2f, 0.f, 0.f), 74.4f),
+        std::make_tuple(Vec3f(-5.f, 4.f, 3.f), Vec3f(0.f, 0.f, 0.f), 0.f),
+        std::make_tuple(Vec3f(5.f, -4.f, 3.f), Vec3f(-1.1f, 0.f, 0.f), -4.4f)
+    ));
+
+
+    // double Vec3d::dot(double xTwo, double yTwo, double zTwo) const
+    class Vec3f_DotScalarScalarF : public Vec3f_VecVecScaFixture {};
+    TEST_P(Vec3f_DotScalarScalarF, Vec3f_DotScalarScalar)
+    {
+        float output = vectorOne.dot(vectorTwo.x, vectorTwo.y, vectorTwo.z);
+        ASSERT_NEAR(expected, output, 1E-06);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_DotScalarScalar, Vec3f_DotScalarScalarF, testing::Values(
+        std::make_tuple(Vec3f(5.f, 4.f, 3.f), Vec3f(6.2f, 2.f, 1.1f), 42.3f),
+        std::make_tuple(Vec3f(-5.f, -4.f, -3.f), Vec3f(-6.2f, 3.f, 1.1f), 15.7f),
+        std::make_tuple(Vec3f(-5.f, 4.f, 3.f), Vec3f(6.2f, 1.f, -1.1f), -30.3f),
+        std::make_tuple(Vec3f(5.f, -4.f, 3.f), Vec3f(6.2f, -2.5f, 1.1f), 44.3f)
+    ));
+
+
+    // Vec3f Vec3f::normalize() const
+    class Vec3f_NormaliseF : public Vec3f_VecVecVecFixture {};
+    TEST_P(Vec3f_NormaliseF, Vec3f_Normalise)
+    {
+        Vec3f output = vectorOne.normalise();
+        ASSERT_NEAR(expected.x, output.x, 1E-05);
+        ASSERT_NEAR(expected.y, output.y, 1E-05);
+        ASSERT_NEAR(expected.z, output.z, 1E-05);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_Normalise, Vec3f_NormaliseF, testing::Values(
+        std::make_tuple(Vec3f(5.f, 5.f, 5.f), Vec3f(0.f, 0.f, 0.f), Vec3f(0.57735f, 0.57735f, 0.57735f)),
+        std::make_tuple(Vec3f(-5.f, -5.f, -5.f), Vec3f(0.f, 0.f, 0.f), Vec3f(-0.57735f, -0.57735f, -0.57735f)),
+        std::make_tuple(Vec3f(-6.f, 8.f, -10.f), Vec3f(0.f, 0.f, 0.f), Vec3f(-0.42426f, 0.56569f, -0.70711f))
+    ));
+
+    class Vec3f_VecFloatFloatFixture : public testing::TestWithParam<std::tuple<Vec3f, float, float, float>>
+    {
+        protected:
+            void SetUp() override
+            {
+                vector = std::get<0>(GetParam());
+                expectedX = std::get<1>(GetParam());
+                expectedY = std::get<2>(GetParam());
+                expectedZ = std::get<3>(GetParam());
+            }
+            Vec3f vector;
+            float expectedX, expectedY, expectedZ;
+    };
+
+    // Vec3f Vec3f::toFloat() const
+    class Vec3f_ConvertToFloatF : public Vec3f_VecFloatFloatFixture {};
+    TEST_P(Vec3f_ConvertToFloatF, Vec3f_ConvertToFloat)
+    { 
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().x));
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().y));   
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().z));   
+        ASSERT_EQ(expectedX, vector.toFloat().x);
+        ASSERT_EQ(expectedY, vector.toFloat().y);   
+        ASSERT_EQ(expectedZ, vector.toFloat().z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_ConvertToFloat, Vec3f_ConvertToFloatF, testing::Values(
+        std::make_tuple(Vec3f(0.f, 0.f, 0.f), 0.f, 0.f, 0.f),
+        std::make_tuple(Vec3f(5.2f, 5.2f, 5.2f), 5.2f, 5.2f, 5.2f),
+        std::make_tuple(Vec3f(-5.2f, -5.2f, -5.2f), -5.2f, -5.2f, -5.2f),
+        std::make_tuple(Vec3f(10.09f, -10.09f, 20.18f), 10.09f, -10.09f, 20.18f)
+    ));
+
+    // Vec3d Vec3f::toDouble() const
+    class Vec3f_ConvertToDoubleF : public Vec3f_VecFloatFloatFixture {};
+    TEST_P(Vec3f_ConvertToDoubleF, Vec3f_ConvertToDouble)
+    { 
+        double expectX = (double)expectedX;
+        double expectY = (double)expectedY;
+        double expectZ = (double)expectedZ;
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().x));
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().y));   
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().z));   
+        ASSERT_NEAR(expectX, vector.toDouble().x, 1E-05);
+        ASSERT_NEAR(expectY, vector.toDouble().y, 1E-05);   
+        ASSERT_NEAR(expectZ, vector.toDouble().z, 1E-05);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3f_ConvertToDouble, Vec3f_ConvertToDoubleF, testing::Values(
+        std::make_tuple(Vec3f(0.f, 0.f, 0.f), 0.f, 0.f, 0.f),
+        std::make_tuple(Vec3f(5.2f, 5.2f, 5.2f), 5.2f, 5.2f, 5.2f),
+        std::make_tuple(Vec3f(-5.2f, -5.2f, -5.2f), -5.2f, -5.2f, -5.2f),
+        std::make_tuple(Vec3f(10.09f, -10.09f, 20.18f), 10.09f, -10.09f, 20.18f)
+    ));
+
+}

--- a/test/Vec3i_Test.cpp
+++ b/test/Vec3i_Test.cpp
@@ -1,0 +1,271 @@
+#include "pch.h"
+#include <VecPlus/Vec3.h>
+#include <iostream>
+
+using namespace vecp;
+
+namespace Vec3i_Tests
+{
+    TEST(Vec3i_TestConstructorDefault, SetDefaultValues)
+    {   
+        Vec3i vector = Vec3i();
+        ASSERT_EQ(vector.x, 0);
+        ASSERT_EQ(vector.y, 0);
+        ASSERT_EQ(vector.z, 0);
+    }
+
+    TEST(Vec3i_TestConstructorValues, SetSpecifiedValues)
+    {
+        Vec3i vector = Vec3i(-3, 4, 5);
+        ASSERT_EQ(vector.x, -3);
+        ASSERT_EQ(vector.y, 4);
+        ASSERT_EQ(vector.z, 5);
+    }
+
+    class Vec3i_VecScaVecFixture : public testing::TestWithParam<std::tuple<Vec3i, int, Vec3i>>
+    {
+        protected:
+            void SetUp() override
+            {
+                vector = std::get<0>(GetParam());
+                scalar = std::get<1>(GetParam());
+                expected = std::get<2>(GetParam());
+            }
+            Vec3i vector, expected;
+            int scalar;
+    };
+
+    class Vec3i_VecVecVecFixture : public testing::TestWithParam<std::tuple<Vec3i, Vec3i, Vec3i>>
+    {
+        protected:
+            void SetUp() override
+            {
+                vectorOne = std::get<0>(GetParam());
+                vectorTwo = std::get<1>(GetParam());
+                expected = std::get<2>(GetParam());
+            }
+            Vec3i vectorOne, vectorTwo, expected;
+    };
+
+    // Vec3i operator + (const Vec3i& vector) const
+    class Vec3i_AddVectorF : public Vec3i_VecVecVecFixture {};
+    TEST_P(Vec3i_AddVectorF, Vec3i_AddVector)
+    {
+        Vec3i output = vectorOne + vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);
+        ASSERT_EQ(expected.z, output.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3i_AddVector, Vec3i_AddVectorF, testing::Values(
+        std::make_tuple(Vec3i(1, 2, 3), Vec3i(3, 4, 5), Vec3i(4, 6, 8)),
+        std::make_tuple(Vec3i(-2, 5, 7), Vec3i(7, -3, 2), Vec3i(5, 2, 9)),
+        std::make_tuple(Vec3i(0, -8, 10), Vec3i(-4, 6, -10), Vec3i(-4, -2, 0)),
+        std::make_tuple(Vec3i(10, -10, 0), Vec3i(-10, 10, 5), Vec3i(0, 0, 5))
+    ));
+
+
+    // void operator += (const Vec3i& vector)
+    class Vec3i_AddEqualsVectorF : public Vec3i_VecVecVecFixture {};
+    TEST_P(Vec3i_AddEqualsVectorF, Vec3i_AddEqualsVector)
+    {
+        vectorOne += vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);
+        ASSERT_EQ(expected.z, vectorOne.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3i_AddEqualsVector, Vec3i_AddEqualsVectorF, testing::Values(
+        std::make_tuple(Vec3i(1, 2, 3), Vec3i(3, 4, 5), Vec3i(4, 6, 8)),
+        std::make_tuple(Vec3i(-2, 5, 7), Vec3i(7, -3, 2), Vec3i(5, 2, 9)),
+        std::make_tuple(Vec3i(0, -8, 10), Vec3i(-4, 6, -10), Vec3i(-4, -2, 0)),
+        std::make_tuple(Vec3i(10, -10, 0), Vec3i(-10, 10, 5), Vec3i(0, 0, 5))
+    ));
+
+    // Vec3i operator - (const Vec3i& vector) const
+    class Vec3i_SubtractVectorF : public Vec3i_VecVecVecFixture {};
+    TEST_P(Vec3i_SubtractVectorF, Vec3i_SubtractVector)
+    {
+        Vec3i output = vectorOne - vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);
+        ASSERT_EQ(expected.z, output.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3i_SubtractVector, Vec3i_SubtractVectorF, testing::Values(
+        std::make_tuple(Vec3i(5, 7, 10), Vec3i(3, 2, 4), Vec3i(2, 5, 6)),
+        std::make_tuple(Vec3i(10, 10, 10), Vec3i(4, 6, 7), Vec3i(6, 4, 3)),
+        std::make_tuple(Vec3i(-3, 8, -9), Vec3i(2, -5, 1), Vec3i(-5, 13, -10)),
+        std::make_tuple(Vec3i(0, 0, 0), Vec3i(-7, 9, 8), Vec3i(7, -9, -8))
+    ));
+
+    // void operator -= (const Vec3i& vector)
+    class Vec3i_SubtractEqualsVectorF : public Vec3i_VecVecVecFixture {};
+    TEST_P(Vec3i_SubtractEqualsVectorF, Vec3i_SubtractEqualsVector)
+    {
+        vectorOne -= vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);
+        ASSERT_EQ(expected.z, vectorOne.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3i_SubtractEqualsVector, Vec3i_SubtractEqualsVectorF, testing::Values(
+        std::make_tuple(Vec3i(5, 7, 10), Vec3i(3, 2, 4), Vec3i(2, 5, 6)),
+        std::make_tuple(Vec3i(10, 10, 10), Vec3i(4, 6, 7), Vec3i(6, 4, 3)),
+        std::make_tuple(Vec3i(-3, 8, -9), Vec3i(2, -5, 1), Vec3i(-5, 13, -10)),
+        std::make_tuple(Vec3i(0, 0, 0), Vec3i(-7, 9, 8), Vec3i(7, -9, -8))
+    ));
+
+    // Vec3i operator * (int scalar) const
+    class Vec3i_MultiplyByScalarF : public Vec3i_VecScaVecFixture {};
+    TEST_P(Vec3i_MultiplyByScalarF, Vec3i_MultiplyByScalar)
+    {
+        Vec3i output = vector * scalar;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);   
+        ASSERT_EQ(expected.z, output.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3i_MultiplyByScalar, Vec3i_MultiplyByScalarF, testing::Values(
+        std::make_tuple(Vec3i(0, 0, 0), 10, Vec3i(0, 0, 0)),
+        std::make_tuple(Vec3i(3, 4, 5), 10, Vec3i(30, 40, 50)),
+        std::make_tuple(Vec3i(-6, 4, -2), 5, Vec3i(-30, 20, -10)),
+        std::make_tuple(Vec3i(8, -7, 6), -5, Vec3i(-40, 35, -30))
+    ));
+
+    // Vec3i operator * (const Vec3i& vector) const
+    class Vec3i_MultiplyByVectorF : public Vec3i_VecVecVecFixture {};
+    TEST_P(Vec3i_MultiplyByVectorF, Vec3i_MultiplyByVector)
+    {
+        Vec3i output = vectorOne * vectorTwo;
+        ASSERT_EQ(expected.x, output.x);
+        ASSERT_EQ(expected.y, output.y);   
+        ASSERT_EQ(expected.z, output.z);
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3i_MultiplyByVector, Vec3i_MultiplyByVectorF, testing::Values(
+        std::make_tuple(Vec3i(0, 0, 0), Vec3i(10, 10, 10), Vec3i(0, 0, 0)),
+        std::make_tuple(Vec3i(3, 4, 5), Vec3i(5, 10, 2), Vec3i(15, 40, 10)),
+        std::make_tuple(Vec3i(-6, 4, 3), Vec3i(5, -5, 7), Vec3i(-30, -20, 21)),
+        std::make_tuple(Vec3i(8, -7, 6), Vec3i(-5, -5, 3), Vec3i(-40, 35, 18))
+    ));
+
+    // void operator *= (int scalar)
+    class Vec3i_MultiplyEqualsByScalarF : public Vec3i_VecScaVecFixture {};
+    TEST_P(Vec3i_MultiplyEqualsByScalarF, Vec3i_MultiplyEqualsByScalar)
+    {
+        vector *= scalar;
+        ASSERT_EQ(expected.x, vector.x);
+        ASSERT_EQ(expected.y, vector.y);   
+        ASSERT_EQ(expected.z, vector.z);
+    }
+    
+    INSTANTIATE_TEST_SUITE_P(Vec3i_MultiplyEqualsByScalar, Vec3i_MultiplyEqualsByScalarF, testing::Values(
+        std::make_tuple(Vec3i(0, 0, 0), 10, Vec3i(0, 0, 0)),
+        std::make_tuple(Vec3i(3, 4, 5), 10, Vec3i(30, 40, 50)),
+        std::make_tuple(Vec3i(-6, 4, -2), 5, Vec3i(-30, 20, -10)),
+        std::make_tuple(Vec3i(8, -7, 6), -5, Vec3i(-40, 35, -30))
+    ));
+
+    // void operator *= (const Vec3i& vector)
+    class Vec3i_MultiplyEqualsByVectorF : public Vec3i_VecVecVecFixture {};
+    TEST_P(Vec3i_MultiplyEqualsByVectorF, Vec3i_MultiplyEqualsByVector)
+    {
+        vectorOne *= vectorTwo;
+        ASSERT_EQ(expected.x, vectorOne.x);
+        ASSERT_EQ(expected.y, vectorOne.y);   
+        ASSERT_EQ(expected.z, vectorOne.z);
+    }
+    
+    INSTANTIATE_TEST_SUITE_P(Vec3i_MultiplyEqualsByVector, Vec3i_MultiplyEqualsByVectorF, testing::Values(
+        std::make_tuple(Vec3i(0, 0, 0), Vec3i(10, 10, 10), Vec3i(0, 0, 0)),
+        std::make_tuple(Vec3i(3, 4, 5), Vec3i(5, 10, 2), Vec3i(15, 40, 10)),
+        std::make_tuple(Vec3i(-6, 4, 3), Vec3i(5, -5, 7), Vec3i(-30, -20, 21)),
+        std::make_tuple(Vec3i(8, -7, 6), Vec3i(-5, -5, 3), Vec3i(-40, 35, 18))
+    ));
+
+    class Vec3i_VecVecBoolFixture : public testing::TestWithParam<std::tuple<Vec3i, Vec3i, bool>>
+    {
+        protected:
+            void SetUp() override
+            {
+                vectorOne = std::get<0>(GetParam());
+                vectorTwo = std::get<1>(GetParam());
+                expected = std::get<2>(GetParam());
+            }
+            Vec3i vectorOne, vectorTwo;
+            bool expected;
+    };
+
+    // bool operator == (const Vec3i& vector) const
+    class Vec3i_CompareVectorsF : public Vec3i_VecVecBoolFixture {};
+    TEST_P(Vec3i_CompareVectorsF, Vec3i_CompareVectors)
+    {
+        bool output = vectorOne == vectorTwo;
+        ASSERT_EQ(expected, output);
+        ASSERT_EQ(expected, output);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3i_CompareVectors, Vec3i_CompareVectorsF, testing::Values(
+        std::make_tuple(Vec3i(-5, 5, 0), Vec3i(-5, 5, 0), true),
+        std::make_tuple(Vec3i(0, 0, 0), Vec3i(0, 0, 0), true),
+        std::make_tuple(Vec3i(-5, 5, 5), Vec3i(5, -5, 5), false),
+        std::make_tuple(Vec3i(6, 0, 7), Vec3i(7, 0, 6), false)
+    ));
+
+
+    class Vec3i_VecFloatFloatFixture : public testing::TestWithParam<std::tuple<Vec3i, float, float, float>>
+    {
+        protected:
+            void SetUp() override
+            {
+                vector = std::get<0>(GetParam());
+                expectedX = std::get<1>(GetParam());
+                expectedY = std::get<2>(GetParam());
+                expectedZ = std::get<3>(GetParam());
+            }
+            Vec3i vector;
+            float expectedX, expectedY, expectedZ;
+    };
+
+    // Vec3f toFloat() const
+    class Vec3i_ConvertToFloatF : public Vec3i_VecFloatFloatFixture {};
+    TEST_P(Vec3i_ConvertToFloatF, Vec3i_ConvertToFloat)
+    { 
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().x));
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().y));   
+        ASSERT_EQ(typeid(float), typeid(vector.toFloat().z));   
+        ASSERT_EQ(expectedX, vector.toFloat().x);
+        ASSERT_EQ(expectedY, vector.toFloat().y);   
+        ASSERT_EQ(expectedZ, vector.toFloat().z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3i_ConvertToFloat, Vec3i_ConvertToFloatF, testing::Values(
+        std::make_tuple(Vec3i(0, 0, 0), 0.f, 0.f, 0.f),
+        std::make_tuple(Vec3i(5, 5, 5), 5.f, 5.f, 5.f),
+        std::make_tuple(Vec3i(-5, -5, -5), -5.f, -5.f, -5.f),
+        std::make_tuple(Vec3i(10, -10, 20), 10.f, -10.f, 20.f)
+    ));
+
+    // Vec3d toDouble() const
+    class Vec3i_ConvertToDoubleF : public Vec3i_VecFloatFloatFixture {};
+    TEST_P(Vec3i_ConvertToDoubleF, Vec3i_ConvertToDouble)
+    { 
+        double expectX = (double)expectedX;
+        double expectY = (double)expectedY;
+        double expectZ = (double)expectedZ;
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().x));
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().y));   
+        ASSERT_EQ(typeid(double), typeid(vector.toDouble().z));   
+        ASSERT_EQ(expectX, vector.toDouble().x);
+        ASSERT_EQ(expectY, vector.toDouble().y);   
+        ASSERT_EQ(expectZ, vector.toDouble().z);   
+    }
+
+    INSTANTIATE_TEST_SUITE_P(Vec3i_ConvertToDouble, Vec3i_ConvertToDoubleF, testing::Values(
+        std::make_tuple(Vec3i(0, 0, 0), 0., 0., 0.),
+        std::make_tuple(Vec3i(5, 5, 5), 5., 5., 5.),
+        std::make_tuple(Vec3i(-5, -5, -5), -5., -5., -5.),
+        std::make_tuple(Vec3i(10, -10, 20), 10., -10., 20.)
+    ));
+}


### PR DESCRIPTION
Added template classes for 3-dimensional vectors; Vec3Decimal<float> (Vec3f), Vec3Decimal<double> (Vec3d) and Vec3Int(int) (Vec3i). All classes have a full suite of unit tests.

The functionality of the classes is very similar to that of the 2-dimensional vectors. The one major difference is in the rotation function for Vec3Decimal<T>. This function accepts an additional argument; a char representing either the 'x', 'y' or 'z' axis. The angle is then used to rotate the point in a 2d plane around that axis.