### PR TITLE
Bugfix/static pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ build
 # VS Code files for those working on multiple tools
 .vscode/*
 *.DS_Store
+/.vs

--- a/include/VecPlus/Vec2Decimal.h
+++ b/include/VecPlus/Vec2Decimal.h
@@ -152,7 +152,7 @@ namespace vecp
         //Vec2fd(T xin = 0., T yin = 0.);
 
     private:
-        double m_pi = 3.141592653589793;
+        inline static constexpr T m_pi = 3.141592653589793;
     }; 
 
     extern template class Vec2Decimal<float>;

--- a/include/VecPlus/Vec3Decimal.h
+++ b/include/VecPlus/Vec3Decimal.h
@@ -151,7 +151,7 @@ namespace vecp
         //Vec2fd(T xin = 0., T yin = 0.);
 
     private:
-        double m_pi = 3.141592653589793;
+        inline static constexpr T m_pi = 3.141592653589793;
     }; 
 
     extern template class Vec3Decimal<float>;

--- a/test/Vec3f_Test.cpp
+++ b/test/Vec3f_Test.cpp
@@ -502,12 +502,12 @@ namespace Vec3f_Tests
         std::make_tuple(Vec3f(5.f, -4.f, 3.f), Vec3f(6.2f, -2.5f, 1.1f), 44.3f)
     ));
 
-    // double Vec3d::dot(double scalar) const
+    // float Vec3f::dot(float scalar) const
     class Vec3f_DotScalarF : public Vec3f_VecVecScaFixture {};
     TEST_P(Vec3f_DotScalarF, Vec3f_DotScalar)
     {
         float output = vectorOne.dot(vectorTwo.x);
-        ASSERT_NEAR(expected, output, 1E-06);
+        ASSERT_NEAR(expected, output, 1E-05);
     }
 
     INSTANTIATE_TEST_SUITE_P(Vec3f_DotScalar, Vec3f_DotScalarF, testing::Values(
@@ -518,12 +518,12 @@ namespace Vec3f_Tests
     ));
 
 
-    // double Vec3d::dot(double xTwo, double yTwo, double zTwo) const
+    // float Vec3f::dot(float xTwo, float yTwo, float zTwo) const
     class Vec3f_DotScalarScalarF : public Vec3f_VecVecScaFixture {};
     TEST_P(Vec3f_DotScalarScalarF, Vec3f_DotScalarScalar)
     {
         float output = vectorOne.dot(vectorTwo.x, vectorTwo.y, vectorTwo.z);
-        ASSERT_NEAR(expected, output, 1E-06);
+        ASSERT_NEAR(expected, output, 1E-05);
     }
 
     INSTANTIATE_TEST_SUITE_P(Vec3f_DotScalarScalar, Vec3f_DotScalarScalarF, testing::Values(


### PR DESCRIPTION
## Overview

The Vec2Decimal and Vec3Decimal classes each contain a variable which holds the value of pi. This variable was declared as non-static which unnecessarily increased the size of each individual object by 50%. 

Both of these variables have been re-declared as static constexpr, to reduce memory usage.